### PR TITLE
Remove bash from script call

### DIFF
--- a/rabies/preprocess_pkg/preprocess_visual_QC.py
+++ b/rabies/preprocess_pkg/preprocess_visual_QC.py
@@ -36,7 +36,7 @@ class PlotOverlap(BaseInterface):
             filename_template+'_registration.png'
 
         from rabies.preprocess_pkg.utils import run_command
-        command = 'bash %s %s %s %s' % (
+        command = '%s %s %s %s' % (
             script_path, self.inputs.moving, self.inputs.fixed, out_name)
         rc = run_command(command)
 


### PR DESCRIPTION
This hard-coded call to bash cases these commands to fail because bash expects the path to a script to run.

Since the script is properly installed and set executable during pip install, its available on the path directly.