### PR TITLE
STC additions

### DIFF
--- a/docs/running_the_software.md
+++ b/docs/running_the_software.md
@@ -165,7 +165,9 @@ usage: rabies preprocess [-h] [--bold_only] [--anat_autobox] [--bold_autobox] [-
                          [--anat_robust_inho_cor ANAT_ROBUST_INHO_COR] [--bold_inho_cor BOLD_INHO_COR] [--bold_robust_inho_cor BOLD_ROBUST_INHO_COR]
                          [--commonspace_reg COMMONSPACE_REG] [--bold2anat_coreg BOLD2ANAT_COREG] [--nativespace_resampling NATIVESPACE_RESAMPLING]
                          [--commonspace_resampling COMMONSPACE_RESAMPLING] [--anatomical_resampling ANATOMICAL_RESAMPLING] [--apply_STC] [--TR TR]
-                         [--tpattern {alt-z,seq-z,alt+z,seq+z}] [--stc_axis {X,Y,Z}] [--anat_template ANAT_TEMPLATE] [--brain_mask BRAIN_MASK]
+                         [--tpattern {alt-z,alt-z2,seq-z,alt+z,alt+z2,seq+z}] [--stc_axis {X,Y,Z}] [--anat_template ANAT_TEMPLATE] 
+                         [--interp_method {linear,cubic,quintic,heptic,wsinc5,wsinc9,fourier}]
+                         [--brain_mask BRAIN_MASK]
                          [--WM_mask WM_MASK] [--CSF_mask CSF_MASK] [--vascular_mask VASCULAR_MASK] [--labels LABELS]
                          bids_dir output_dir
 
@@ -347,17 +349,26 @@ STC Options:
   --TR TR               Specify repetition time (TR) in seconds. (e.g. --TR 1.2)
                         (default: auto)
                         
-  --tpattern {alt-z,seq-z,alt+z,seq+z}
+  --tpattern {alt-z,alt-z2,seq-z,alt+z,alt+z2,seq+z}
                         Specify if interleaved ('alt') or sequential ('seq') acquisition, and specify in which 
                         direction (- or +) to apply the correction. If slices were acquired from front to back, 
-                        the correction should be in the negative (-) direction. Refer to this discussion on the 
-                        topic for more information https://github.com/CoBrALab/RABIES/discussions/217.
+                        the correction should be in the negative (-) direction. If slices were collected in an interleaved
+                        order starting with the second or (second-to-last) slice, use 'alt+z2' or 'alt-z2'.
+                        Refer to this discussion on the topic for more information https://github.com/CoBrALab/RABIES/discussions/217.
                         (default: alt-z)
                         
   --stc_axis {X,Y,Z}    Can specify over which axis of the image the STC must be applied. Generally, the correction 
                         should be over the Y axis, which corresponds to the anteroposterior axis in RAS convention. 
                         (default: Y)
-                        
+
+  --interp_method {linear,cubic,quintic,heptic,wsinc5,wsinc9,fourier}
+                        Can specify the interpolation method used for STC. Polynomial methods (e.g., linear, cubic, etc.)
+                        will introduce greater autocorrelation to the interpolated timeseries, while wsinc and fourier methods
+                        will introduce less (or none). Refer to this discussion on the topic for more information
+                        https://github.com/CoBrALab/RABIES/discussions/267.
+                        (default: quintic) 
+            
+
 
 Template Files:
   Specify commonspace template and associated mask/label files. By default, RABIES

--- a/docs/running_the_software.md
+++ b/docs/running_the_software.md
@@ -366,7 +366,7 @@ STC Options:
                         will introduce greater autocorrelation to the interpolated timeseries, while wsinc and fourier methods
                         will introduce less (or none). Refer to this discussion on the topic for more information
                         https://github.com/CoBrALab/RABIES/discussions/267.
-                        (default: quintic) 
+                        (default: fourier) 
             
 
 

--- a/rabies/parser.py
+++ b/rabies/parser.py
@@ -388,11 +388,12 @@ def get_parser():
         )
     g_stc.add_argument(
         '--tpattern', type=str, default='alt-z',
-        choices=['alt-z', 'seq-z', 'alt+z', 'seq+z'],
+        choices=['alt-z', 'alt-z2', 'seq-z', 'alt+z', 'alt+z2', 'seq+z'],
         help=
             "Specify if interleaved ('alt') or sequential ('seq') acquisition, and specify in which \n"
             "direction (- or +) to apply the correction. If slices were acquired from front to back, \n"
-            "the correction should be in the negative (-) direction. Refer to this discussion on the \n"
+            "the correction should be in the negative (-) direction. If slices were collected in an interleaved \n"
+            "order starting with the second or (second-to-last) slice, use 'alt+z2' or 'alt-z2'. Refer to this discussion on the \n"
             "topic for more information https://github.com/CoBrALab/RABIES/discussions/217.\n"
             "(default: %(default)s)\n"
             "\n"
@@ -406,7 +407,17 @@ def get_parser():
             "(default: %(default)s)\n"
             "\n"
         )
-
+    g_stc.add_argument(
+        '--interp_method', type=str, default='quintic',
+        choices=['linear', 'cubic', 'quintic', 'heptic', 'wsinc5', 'wsinc9', 'fourier'],
+        help=
+            "Can specify the interpolation method used for STC. Polynomial methods (e.g., linear, cubic, etc.) \n"
+            "will introduce greater autocorrelation to the interpolated timeseries, while wsinc and fourier methods \n"
+            "will introduce less (or none). Refer to this discussion on the topic for more information \n"
+            "https://github.com/CoBrALab/RABIES/discussions/267. \n"
+            "(default: %(default)s)\n"
+            "\n"
+        )
     g_atlas = preprocess.add_argument_group(
         title='Template Files', 
         description=

--- a/rabies/parser.py
+++ b/rabies/parser.py
@@ -408,7 +408,7 @@ def get_parser():
             "\n"
         )
     g_stc.add_argument(
-        '--interp_method', type=str, default='quintic',
+        '--interp_method', type=str, default='fourier',
         choices=['linear', 'cubic', 'quintic', 'heptic', 'wsinc5', 'wsinc9', 'fourier'],
         help=
             "Can specify the interpolation method used for STC. Polynomial methods (e.g., linear, cubic, etc.) \n"

--- a/rabies/preprocess_pkg/stc.py
+++ b/rabies/preprocess_pkg/stc.py
@@ -38,7 +38,7 @@ def init_bold_stc_wf(opts, name='bold_stc_wf'):
     return workflow
 
 
-def slice_timing_correction(in_file, tr='auto', tpattern='alt-z', stc_axis='Y', interp_method = 'quintic', rabies_data_type=8):
+def slice_timing_correction(in_file, tr='auto', tpattern='alt-z', stc_axis='Y', interp_method = 'fourier', rabies_data_type=8):
     '''
     This functions applies slice-timing correction on the anterior-posterior
     slice acquisition direction. The input image, assumed to be in RAS orientation


### PR DESCRIPTION
Added 'alt+z2' and 'alt-z2' to tpattern options for slice time correction, as well as the ability to specify the interpolation method used by 3dTshift. It might also be worth considering changing the default from quintic to one of the more recent methods (wsinc or fourier). 