### PR TITLE
fix: pin traits < 7.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ sphinxcontrib-programoutput
 jinja2==3.1.1
 pillow==10.1.0
 rabies==0.5.1
+traits<7.0


### PR DESCRIPTION
issue with nipype==1.6.1 and traits 7.0. 
downgrading traits to <7.0 in docs/requirements. 
this might be an issue in RABIES docker

addressing #414 