### PR TITLE
fix: pin traits < 7.0, change urls for mouse templates

### DIFF
--- a/.github/workflows/docker-build-PR.yml
+++ b/.github/workflows/docker-build-PR.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           context: .
           push: false
-          tags: RABIES:pr-${{ github.event.pull_request.number }}
+          tags: rabies:pr-${{ github.event.pull_request.number }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker-build-PR.yml
+++ b/.github/workflows/docker-build-PR.yml
@@ -2,8 +2,8 @@ name: PR Workflow - test that dockerfile will build on a PR to master
 
 on:
   pull_request:
-    branches: "master"
-
+    branches:
+      - master
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-PR.yml
+++ b/.github/workflows/docker-build-PR.yml
@@ -1,0 +1,26 @@
+name: PR Workflow - test that dockerfile will build on a PR to master
+
+on:
+  pull_request:
+    branches: "master"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and tag image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: false
+          tags: RABIES:pr-${{ github.event.pull_request.number }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/rabies_environment.dev.yml
+++ b/rabies_environment.dev.yml
@@ -21,5 +21,6 @@ dependencies:
   - simpleitk
   - fsl-base
   - fsl-melodic
+  - traits<7.0
   - pip:
-    - qbatch
+      - qbatch

--- a/rabies_environment.yml
+++ b/rabies_environment.yml
@@ -22,5 +22,6 @@ dependencies:
   - networkx<3
   - fsl-base=2309.1
   - fsl-melodic=2111.3
+  - traits<7.0
   - pip:
-    - qbatch==2.3
+      - qbatch==2.3

--- a/scripts/install_DSURQE.sh
+++ b/scripts/install_DSURQE.sh
@@ -1,22 +1,14 @@
 #!/bin/bash
 set -euo pipefail
-tmpdir=$(mktemp -d)
 
 out_dir=$1
 mkdir -p $out_dir
 
 # Download DSURQE template
-curl -L --retry 5 -o ${tmpdir}/DSURQE_40micron_average.mnc http://repo.mouseimaging.ca/repo/DSURQE_40micron/DSURQE_40micron_average.mnc
-curl -L --retry 5 -o ${tmpdir}/DSURQE_40micron_labels.mnc http://repo.mouseimaging.ca/repo/DSURQE_40micron/DSURQE_40micron_labels.mnc
-curl -L --retry 5 -o ${tmpdir}/DSURQE_40micron_mask.mnc http://repo.mouseimaging.ca/repo/DSURQE_40micron/DSURQE_40micron_mask.mnc
-curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_R_mapping.csv http://repo.mouseimaging.ca/repo/DSURQE_40micron/DSURQE_40micron_R_mapping.csv
-
-# convert to nifti
-mnc2nii ${tmpdir}/DSURQE_40micron_average.mnc ${out_dir}/DSURQE_40micron_average.nii
-mnc2nii ${tmpdir}/DSURQE_40micron_labels.mnc ${out_dir}/DSURQE_40micron_labels.nii
-mnc2nii ${tmpdir}/DSURQE_40micron_mask.mnc ${out_dir}/DSURQE_40micron_mask.nii
-
-gzip -f ${out_dir}/DSURQE_40micron_*.nii
+curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_average.nii.gz https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron.nii.gz
+curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_labels.nii.gz https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_labels.nii.gz
+curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_mask.nii.gz https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_mask.nii.gz
+curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_R_mapping.csv https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_R_mapping.csv
 
 # create regional masks
 gen_DSURQE_masks.py ${out_dir}/DSURQE_40micron_labels.nii.gz ${out_dir}/DSURQE_40micron_R_mapping.csv ${out_dir}/DSURQE_40micron
@@ -34,4 +26,3 @@ curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_vascular_mask.nii.
 curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_labels.nii.gz -o ${out_dir}/EPI_labels.nii.gz
 curl -L --retry 5 https://zenodo.org/record/5118030/files/melodic_IC_resampled.nii.gz -o ${out_dir}/melodic_IC_resampled.nii.gz
 
-rm -rf ${tmpdir}

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 import sys
 from shutil import rmtree
 
-from setuptools import find_packages, setup, Command
+from setuptools import Command, find_packages, setup
 
 # Package meta-data.
 NAME = 'rabies'
@@ -35,7 +35,8 @@ REQUIRED = [
     'seaborn==0.11.1',
     'simpleitk==2.0.2',
     'qbatch==2.3',
-    'networkx<3'
+    'networkx<3',
+    'traits<7.0'
 ]
 
 # What packages are optional?


### PR DESCRIPTION
`docker build` successful on a DNP workstation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added a version constraint for the `traits` package (<7.0) in environment and dependency files.
  - Corrected indentation for a pip dependency in environment configurations.
  - Streamlined installation by directly downloading pre-converted NIfTI files, removing local conversion steps.
  - Introduced a new GitHub Actions workflow to automate Docker image builds for pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->