### PR TITLE
Ci/apptainer on release

### DIFF
--- a/.github/workflows/apptainer-attach-on-release.yml
+++ b/.github/workflows/apptainer-attach-on-release.yml
@@ -1,0 +1,38 @@
+name: Build and Attach Apptainer Image from Docker URL to Release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build-and-attach:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install Apptainer
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          sudo add-apt-repository -y ppa:apptainer/ppa
+          sudo apt-get update
+          sudo apt-get install -y apptainer
+
+      - name: Get release version
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Build Apptainer image from Docker URL
+        run: |
+          REPO_LOWERCASE=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          sudo apptainer build app-${{ steps.get_version.outputs.VERSION }}.sif docker://ghcr.io/${REPO_LOWERCASE}:latest
+
+      - name: Upload image to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: app-${{ steps.get_version.outputs.VERSION }}.sif
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apptainer-attach-on-release.yml
+++ b/.github/workflows/apptainer-attach-on-release.yml
@@ -18,7 +18,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository -y ppa:apptainer/ppa
-          sudo apt-get update
           sudo apt-get install -y apptainer
 
       - name: Get release version
@@ -28,7 +27,8 @@ jobs:
       - name: Build Apptainer image from Docker URL
         run: |
           REPO_LOWERCASE=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
-          sudo apptainer build app-${{ steps.get_version.outputs.VERSION }}.sif docker://ghcr.io/${REPO_LOWERCASE}:latest
+          VERSION=${{ steps.get_version.outputs.VERSION }}
+          sudo apptainer build app-${VERSION}.sif docker://ghcr.io/${REPO_LOWERCASE}:${VERSION}
 
       - name: Upload image to release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/apptainer-attach-on-release.yml
+++ b/.github/workflows/apptainer-attach-on-release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Apptainer
         run: |
@@ -22,16 +22,16 @@ jobs:
 
       - name: Get release version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
 
       - name: Build Apptainer image from Docker URL
         run: |
           REPO_LOWERCASE=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
           VERSION=${{ steps.get_version.outputs.VERSION }}
-          sudo apptainer build app-${VERSION}.sif docker://ghcr.io/${REPO_LOWERCASE}:${VERSION}
+          sudo apptainer build "app-${VERSION}.sif" "docker://ghcr.io/${REPO_LOWERCASE}:${VERSION}"
 
       - name: Upload image to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: app-${{ steps.get_version.outputs.VERSION }}.sif
         env:

--- a/rabies/parser.py
+++ b/rabies/parser.py
@@ -1,6 +1,7 @@
-import os
 import argparse
+import os
 from pathlib import Path
+
 import pathos.multiprocessing as multiprocessing  # Better multiprocessing
 
 if 'XDG_DATA_HOME' in os.environ.keys():
@@ -955,7 +956,7 @@ def get_parser():
         )
     analysis.add_argument(
         "--ROI_csv", action='store', type=Path, 
-        default=f"{rabies_path}/DSURQE_40micron_labels.nii.gz",
+        default=f"{rabies_path}/DSURQE_40micron_R_mapping.csv",
         help=
             "A CSV file with the ROI names matching the ROI index numbers in the atlas labels Nifti file. \n"
             "A copy of this file is provided along the FC matrix generated for each subject.\n"
@@ -1197,6 +1198,7 @@ def parse_scan_QC_thresholds(opt):
         opt=s[:-len(f'{replace}')] # remove the extra addition at the end
 
     import ast
+
     # using ast.literal_eval()
     # convert dictionary string to dictionary
     try:

--- a/scripts/install_DSURQE.sh
+++ b/scripts/install_DSURQE.sh
@@ -4,11 +4,57 @@ set -euo pipefail
 out_dir=$1
 mkdir -p $out_dir
 
-# Download DSURQE template
-curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_average.nii.gz https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron.nii.gz
-curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_labels.nii.gz https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_labels.nii.gz
-curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_mask.nii.gz https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_mask.nii.gz
-curl -L --retry 5 -o ${out_dir}/DSURQE_40micron_R_mapping.csv https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_R_mapping.csv
+
+files=(
+    "DSURQE_40micron_average.nii"
+    "DSURQE_40micron_labels.nii"
+    "DSURQE_40micron_mask.nii"
+    "DSURQE_40micron_R_mapping.csv"
+)
+fallback_files=(
+    "DSURQE_40micron_average.nii.gz"
+    "DSURQE_40micron_labels.nii.gz"
+    "DSURQE_40micron_mask.nii.gz"
+    "DSURQE_40micron_R_mapping.csv"
+)
+
+# Primary URLs (mouseimaging.ca)
+primary_urls=(
+    "https://www.mouseimaging.ca/repo/DSURQE_40micron/Dorr_2008_Steadman_2013_Ullmann_2013_Richards_2011_Qiu_2016_Egan_2015_40micron/nifti/DSURQE_40micron_average.nii"
+    "https://www.mouseimaging.ca/repo/DSURQE_40micron/Dorr_2008_Steadman_2013_Ullmann_2013_Richards_2011_Qiu_2016_Egan_2015_40micron/nifti/DSURQE_40micron_labels.nii"
+    "https://www.mouseimaging.ca/repo/DSURQE_40micron/Dorr_2008_Steadman_2013_Ullmann_2013_Richards_2011_Qiu_2016_Egan_2015_40micron/nifti/DSURQE_40micron_mask.nii"
+    "https://www.mouseimaging.ca/repo/DSURQE_40micron/Dorr_2008_Steadman_2013_Ullmann_2013_Richards_2011_Qiu_2016_Egan_2015_40micron/mappings/DSURQE_40micron_R_mapping.csv"
+)
+
+# Fallback URLs (github)
+fallback_urls=(
+    "https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron.nii.gz"
+    "https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_labels.nii.gz"
+    "https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_mask.nii.gz"
+    "https://github.com/CoBrALab/RABIES/releases/download/0.5.1/DSURQE_40micron_R_mapping.csv"
+)
+
+# Try to download from mouseimaging first, if that doesn't work download from github
+primary_success=true
+for i in {0..3}; do
+    if ! curl -L --retry 5 --fail --silent --show-error -o "${out_dir}/${files[$i]}" "${primary_urls[$i]}"; then
+        primary_success=false
+        break
+    fi
+done
+
+if [ "$primary_success" = true]; then
+  gzip -f ${out_dir}/DSURQE_40micron_*.nii
+fi
+
+# if these fail too exit 1
+if [ "$primary_success" = false ]; then
+    for i in {0..3}; do
+        if ! curl -L --retry 5 --fail --silent --show-error -o "${out_dir}/${fallback_files[$i]}" "${fallback_urls[$i]}"; then
+            exit 1
+        fi
+    done
+fi
 
 # create regional masks
 gen_DSURQE_masks.py ${out_dir}/DSURQE_40micron_labels.nii.gz ${out_dir}/DSURQE_40micron_R_mapping.csv ${out_dir}/DSURQE_40micron

--- a/scripts/install_DSURQE.sh
+++ b/scripts/install_DSURQE.sh
@@ -44,7 +44,9 @@ for i in {0..3}; do
 done
 
 if [ "$primary_success" = true ]; then
-  gzip -f ${out_dir}/DSURQE_40micron_*.nii
+  for f in "${out_dir}"DSURQE_40micron_*.nii; do
+    gzip -f "$f"
+  done
 fi
 
 # if these fail too exit 1

--- a/scripts/install_DSURQE.sh
+++ b/scripts/install_DSURQE.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 out_dir=$1
-mkdir -p $out_dir
+mkdir -p "$out_dir"
 
 
 files=(
@@ -43,7 +43,7 @@ for i in {0..3}; do
     fi
 done
 
-if [ "$primary_success" = true]; then
+if [ "$primary_success" = true ]; then
   gzip -f ${out_dir}/DSURQE_40micron_*.nii
 fi
 
@@ -59,16 +59,14 @@ fi
 # create regional masks
 gen_DSURQE_masks.py ${out_dir}/DSURQE_40micron_labels.nii.gz ${out_dir}/DSURQE_40micron_R_mapping.csv ${out_dir}/DSURQE_40micron
 
-# download additional supportive files
-curl -L --retry 5 https://zenodo.org/record/5118030/files/melodic_IC.nii.gz -o ${out_dir}/melodic_IC.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/vascular_mask.nii.gz -o ${out_dir}/vascular_mask.nii.gz
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/melodic_IC.nii.gz" -o "${out_dir}/melodic_IC.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/vascular_mask.nii.gz" -o "${out_dir}/vascular_mask.nii.gz"
 
 # download atlas file versions for the EPI template
-curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_template.nii.gz -o ${out_dir}/EPI_template.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_brain_mask.nii.gz -o ${out_dir}/EPI_brain_mask.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_WM_mask.nii.gz -o ${out_dir}/EPI_WM_mask.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_CSF_mask.nii.gz -o ${out_dir}/EPI_CSF_mask.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_vascular_mask.nii.gz -o ${out_dir}/EPI_vascular_mask.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/EPI_labels.nii.gz -o ${out_dir}/EPI_labels.nii.gz
-curl -L --retry 5 https://zenodo.org/record/5118030/files/melodic_IC_resampled.nii.gz -o ${out_dir}/melodic_IC_resampled.nii.gz
-
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/EPI_template.nii.gz" -o "${out_dir}/EPI_template.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/EPI_brain_mask.nii.gz" -o "${out_dir}/EPI_brain_mask.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/EPI_WM_mask.nii.gz" -o "${out_dir}/EPI_WM_mask.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/EPI_CSF_mask.nii.gz" -o "${out_dir}/EPI_CSF_mask.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/EPI_vascular_mask.nii.gz" -o "${out_dir}/EPI_vascular_mask.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/EPI_labels.nii.gz" -o "${out_dir}/EPI_labels.nii.gz"
+curl -L --retry 5 "https://zenodo.org/record/5118030/files/melodic_IC_resampled.nii.gz" -o "${out_dir}/melodic_IC_resampled.nii.gz"


### PR DESCRIPTION
- fix ROI_csv path #406 
- feature: apptainer image now attaches on release #325 
testing on my fork
[release](https://github.com/CMonnin/RABIES/releases/tag/0.1.1-alpha-e)
[action](https://github.com/CMonnin/RABIES/actions/runs/15146083906)
- refactor: added back in links to download from [mouseimaging.ca](https://www.mouseimaging.ca/repo/DSURQE_40micron/Dorr_2008_Steadman_2013_Ullmann_2013_Richards_2011_Qiu_2016_Egan_2015_40micron/nifti/)  
- now the .nii files rather than the mnc




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated workflow to build and attach Apptainer images to releases.

* **Bug Fixes**
  * Improved DSURQE template installation script with a fallback download mechanism and enhanced error handling.

* **Other Changes**
  * Updated default value for an analysis argument to use a CSV file instead of a NIfTI file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->