### PR TITLE
switched to version 0.5.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,8 +10,8 @@ authors:
 - family-names: "Chakravarty"
   given-names: "M. Mallar"
 title: "RABIES: Rodent Automated Bold Improvement of EPI Sequences."
-version: 0.5.1
-date-released: 2023-11-12
+version: 0.5.2
+date-released: 2025-06-30
 url: "https://github.com/CoBrALab/RABIES"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2019, CoBrALab and Gabriel Desrosiers-Gregoire and Gabriel A. Deven
 author = 'CoBrALab'
 
 # The full version, including alpha/beta/rc tags
-release = '0.5.1'
+release = '0.5.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,5 +6,5 @@ sphinxcontrib-bibtex
 sphinxcontrib-programoutput
 jinja2==3.1.1
 pillow==10.1.0
-rabies==0.5.1
+rabies==0.5.2
 traits<7.0

--- a/rabies/__version__.py
+++ b/rabies/__version__.py
@@ -3,6 +3,6 @@
 # 88YbdP88   8P   88"""   dP__Yb  Yb      88"Yb   dP__Yb  Yb  "88 88""
 # 88 YY 88  dP    88     dP""""Yb  YboodP 88  Yb dP""""Yb  YboodP 888888
 
-VERSION = (0, 5, 1)
+VERSION = (0, 5, 2)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
next RABIES version release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version number to 0.5.2 across documentation, citation, and internal version references.
  * Revised release date in citation details.
  * Updated documentation requirements to reference the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->