### PR TITLE
FIX: Change mask default from 'NULL' to 'NOMASK' in registration.py

### DIFF
--- a/rabies/preprocess_pkg/registration.py
+++ b/rabies/preprocess_pkg/registration.py
@@ -104,7 +104,7 @@ def init_cross_modal_reg_wf(opts, name='cross_modal_reg_wf'):
     return workflow
 
 
-def run_antsRegistration(reg_method, brain_extraction=False, keep_mask_after_extract=False, moving_image='NULL', moving_mask='NULL', fixed_image='NULL', fixed_mask='NULL', rabies_data_type=8):
+def run_antsRegistration(reg_method, brain_extraction=False, keep_mask_after_extract=False, moving_image='NULL', moving_mask='NOMASK', fixed_image='NULL', fixed_mask='NOMASK', rabies_data_type=8):
     import os
     import pathlib  # Better path manipulation
     filename_split = pathlib.Path(moving_image).name.rsplit(".nii")


### PR DESCRIPTION
minc-toolkit-extras/antsRegistration_affine_SyN.sh needs 'NOMASK' instead of 'NULL' for non-specified mask images. ANTS will crash for argument `--moving-mask NULL`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default mask handling in image registration: both moving and fixed images now use “no mask” by default, preventing issues caused by previous NULL defaults and ensuring consistent no-mask behavior.
  * No other registration behavior is changed. If your workflow relied on the old NULL semantics, specify masks explicitly to retain prior behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->