### PR TITLE
chore: add workflow dispatch to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build-PR.yml
+++ b/.github/workflows/docker-build-PR.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           context: .
           push: false
-          tags: rabies:pr-${{ github.event.pull_request.number }}
+          tags: rabies:pr-${{ github.event.pull_request.number || 'manual' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow can now be started manually to trigger Docker image builds.
  * Docker image tagging now falls back to a "manual" tag when a PR number is unavailable, ensuring consistent tags for manual runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->