### PR TITLE
fix: created to published tag and manual triggering

### DIFF
--- a/.github/workflows/apptainer-attach-on-release.yml
+++ b/.github/workflows/apptainer-attach-on-release.yml
@@ -1,38 +1,48 @@
 name: Build and Attach Apptainer Image from Docker URL to Release
-
 on:
   release:
     types:
-      - created
+      - published
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name (e.g., 0.5.0)'
+        required: true
+        type: string
 
 jobs:
   build-and-attach:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
+      
       - name: Install Apptainer
         run: |
           sudo apt-get update
           sudo apt-get install -y software-properties-common
           sudo add-apt-repository -y ppa:apptainer/ppa
           sudo apt-get install -y apptainer
-
+      
       - name: Get release version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "VERSION=${{ inputs.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+      
       - name: Build Apptainer image from Docker URL
         run: |
           REPO_LOWERCASE=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
           VERSION=${{ steps.get_version.outputs.VERSION }}
           sudo apptainer build "app-${VERSION}.sif" "docker://ghcr.io/${REPO_LOWERCASE}:${VERSION}"
-
+      
       - name: Upload image to release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.get_version.outputs.VERSION }}
           files: app-${{ steps.get_version.outputs.VERSION }}.sif
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger when releases are published to the public, rather than when initially created
  * Added support for manual workflow dispatch, allowing release builds to be triggered with custom tag names for testing or special releases
  * Enhanced version extraction and release upload process to handle both automatic and manual release workflows consistently and reliably

<!-- end of auto-generated comment: release notes by coderabbit.ai -->