### PR TITLE
Fix container package page to recommend :latest tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -85,13 +85,20 @@ jobs:
         id: latest-release
         if: github.event_name != 'pull_request'
         run: |
-          LATEST_TAG=$(gh release view --json tagName -q .tagName)
-          echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            LATEST_TAG="${{ github.ref_name }}"
+          else
+            LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
+          fi
+
+          if [ -n "$LATEST_TAG" ]; then
+            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tag latest release as :latest
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && steps.latest-release.outputs.tag != ''
         run: |
           IMAGE_LOWER=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           docker buildx imagetools create \

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,6 +63,8 @@ jobs:
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -76,3 +78,22 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Re-tag the latest release image as :latest so the GitHub Packages
+      # page always recommends :latest instead of :master
+      - name: Get latest release tag
+        id: latest-release
+        if: github.event_name != 'pull_request'
+        run: |
+          LATEST_TAG=$(gh release view --json tagName -q .tagName)
+          echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Tag latest release as :latest
+        if: github.event_name != 'pull_request'
+        run: |
+          IMAGE_LOWER=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
+          docker buildx imagetools create \
+            "${IMAGE_LOWER}:${{ steps.latest-release.outputs.tag }}" \
+            --tag "${IMAGE_LOWER}:latest"


### PR DESCRIPTION
## Summary
- Disable `docker/metadata-action`'s automatic `:latest` tagging (`flavor: latest=false`)
- After every build, re-tag the latest GitHub release image as `:latest` using `docker buildx imagetools create` (server-side retag, no layer transfer)
- This ensures `:latest` is always the most recently pushed tag on the ghcr.io package page, so it gets recommended instead of `:master`

## Test plan
- [ ] Merge and verify the next master push triggers the workflow successfully
- [ ] Check https://github.com/CoBrALab/RABIES/pkgs/container/rabies shows `:latest` as the recommended tag
- [ ] Verify `:latest` points to the same image digest as the current release tag (`0.6.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Docker image tagging so the :latest tag is applied only for actual releases and reliably points to the most recent release, improving registry discoverability.
  * Prevented automatic :latest tagging for pull-request events to avoid accidental overwrites of the latest image.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->