### PR TITLE
Keep mean cr

### DIFF
--- a/rabies/analysis_pkg/main_wf.py
+++ b/rabies/analysis_pkg/main_wf.py
@@ -74,11 +74,13 @@ def init_main_analysis_wf(preprocess_opts, cr_opts, analysis_opts):
     if not os.path.isfile(str(analysis_opts.prior_maps)):
         raise ValueError("--prior_maps doesn't exists.")
 
-    load_CR_dict_node = pe.Node(Function(input_names=['maps_dict_file', 'cleaned_bold_file', 'CR_data_dict', 'VE_file', 'STD_file', 'CR_STD_file', 'name_source'],
+    load_CR_dict_node = pe.Node(Function(input_names=['maps_dict_file', 'cleaned_bold_file', 'CR_data_dict', 'VE_file', 'STD_file', 'CR_STD_file', 'name_source', 'remove_intercept'],
                                            output_names=[
                                                'CR_dict_file'],
                                        function=load_CR_input_dict),
                               name='load_CR_dict_node')
+    # if the average was kept, it needs to be removed before analysis computations
+    load_CR_dict_node.inputs.remove_intercept = cr_opts.keep_EPI_average
 
     # prepare analysis workflow
     analysis_output = os.path.abspath(str(analysis_opts.output_dir))
@@ -461,7 +463,7 @@ def load_maps_dict(mask_file, WM_mask_file, CSF_mask_file, atlas_file, anat_ref_
 
 
 # this function loads subject-specific data from confound correction
-def load_CR_input_dict(maps_dict_file, cleaned_bold_file, CR_data_dict, VE_file, STD_file, CR_STD_file, name_source):
+def load_CR_input_dict(maps_dict_file, cleaned_bold_file, CR_data_dict, VE_file, STD_file, CR_STD_file, name_source, remove_intercept=False):
     import pickle
     import pathlib
     import os
@@ -472,13 +474,11 @@ def load_CR_input_dict(maps_dict_file, cleaned_bold_file, CR_data_dict, VE_file,
         maps_dict = pickle.load(handle)
 
     volume_indices = maps_dict['volume_indices']
+    timeseries = sitk.GetArrayFromImage(sitk.ReadImage(cleaned_bold_file))[:,volume_indices] # read directly as a 2D array
 
-    data_img = sitk.ReadImage(cleaned_bold_file)
-    data_array = sitk.GetArrayFromImage(data_img)
-    num_volumes = data_array.shape[0]
-    timeseries = np.zeros([num_volumes, volume_indices.sum()])
-    for i in range(num_volumes):
-        timeseries[i, :] = (data_array[i, :, :, :])[volume_indices]
+    if remove_intercept:
+        # remove the intercept that was added since analysis computations expect mean-centered data
+        timeseries -= CR_data_dict['voxelwise_mean']
 
     VE_spatial = sitk.GetArrayFromImage(
         sitk.ReadImage(VE_file))[volume_indices]

--- a/rabies/confound_correction_pkg/confound_correction.py
+++ b/rabies/confound_correction_pkg/confound_correction.py
@@ -227,6 +227,7 @@ class CleanImage(BaseInterface):
                 generate_CR_null=cr_opts.generate_CR_null,
                 scale_variance_voxelwise=cr_opts.scale_variance_voxelwise,
                 image_scaling=cr_opts.image_scaling,
+                keep_EPI_average=cr_opts.keep_EPI_average,
                 smoothing_filter=cr_opts.smoothing_filter,
                 slicewise_correction_direction=cr_opts.slicewise_correction_direction,
                 nipype_log=nipype_log,
@@ -313,6 +314,7 @@ def clean_image(input_bold, brain_mask, FD_csv, motion_params_csv, # necessary i
                 match_number_timepoints=False, highpass=None, lowpass=None, edge_cutoff=0,
                 nuisance_regressors = [], generate_CR_null=False,
                 scale_variance_voxelwise=False,image_scaling='grand_mean_scaling',
+                keep_EPI_average=False,
                 smoothing_filter=None,
                 slicewise_correction_direction = 'Off',
                 nipype_log=None,
@@ -415,6 +417,18 @@ def clean_image(input_bold, brain_mask, FD_csv, motion_params_csv, # necessary i
     image_scaling : str, default='grand_mean_scaling'
         Method for image scaling, select among: "None", "global_variance", 
         "voxelwise_standardization", "grand_mean_scaling", "voxelwise_mean"
+
+    keep_EPI_average : bool, default=False
+        This option allows to re-introduce the voxelwise average that was removed during
+        detrending at the end of confound correction, so that the original EPI background 
+        intensity is preserved.
+        Specifically, the intercept that is calculated from the linear model during 
+        detrending is re-introduced. This intercept is also subjected to the same 
+        image_scaling as the timeseries, so as to retain the proportion between the 
+        average and variance of timeseries.
+        Because this parameter re-introduces the intercept from detrending, if the 
+        trend was estimated over a specific time intervel with detrending_time_interval,
+        the intercept is the average over that time interval.
 
     smoothing_filter : float, default=None
         Gaussian smoothing filter to apply.
@@ -585,8 +599,8 @@ def clean_image(input_bold, brain_mask, FD_csv, motion_params_csv, # necessary i
     '''
     #3 - Linear/Quadratic detrending of fMRI timeseries and nuisance regressors
     '''
-    timeseries, voxelwise_intercept = cr_utils.remove_trend(timeseries, frame_mask, order = detrending_order, time_interval = detrending_time_interval)
-    motion_regressors_array, _ = cr_utils.remove_trend(motion_regressors_array, frame_mask, order = detrending_order, time_interval = detrending_time_interval)
+    timeseries, voxelwise_intercept = cr_utils.remove_trend(timeseries, frame_mask, order = detrending_order, time_interval = detrending_time_interval, remove_intercept=True)
+    motion_regressors_array, _ = cr_utils.remove_trend(motion_regressors_array, frame_mask, order = detrending_order, time_interval = detrending_time_interval, remove_intercept=True)
 
     '''
     #4 - Apply ICA-AROMA.
@@ -781,6 +795,14 @@ def clean_image(input_bold, brain_mask, FD_csv, motion_params_csv, # necessary i
         else:
             timeseries_img = cr_utils.smooth_image(
                 timeseries_img, smoothing_filter, brain_mask)
+
+    voxelwise_intercept /= scaling_factor # the intercept is also scaling, so that the mean and variance remain proportional to the original data
+    if keep_EPI_average:
+        # this needs to be done after smoothing, because the intercept would impact smoothing results
+        timeseries = sitk.GetArrayFromImage(timeseries_img)[:,volume_idx]
+        del timeseries_img
+        timeseries += voxelwise_intercept
+        timeseries_img = recover_4D(brain_mask, timeseries, header_geo)
 
     # save output files
     VE_spatial_map = recover_3D(brain_mask, VE_spatial)

--- a/rabies/confound_correction_pkg/utils.py
+++ b/rabies/confound_correction_pkg/utils.py
@@ -454,7 +454,7 @@ def nuisance_regression(timeseries_vol, motion_regressors_array, TR, frame_mask,
     return timeseries_vol, predicted_vol, predicted_random_vol, num_regressors, VE_temporal, VE_spatial, VE_total_ratio, cleaned_slice_l
 
 
-def remove_trend(timeseries, frame_mask, order=1 , time_interval='0-end'):
+def remove_trend(timeseries, frame_mask, order=1 , time_interval='0-end', remove_intercept=True):
     '''The timeseries is already censored, we need to create a timeseries that is censored with the same time mask so that it matches'''
     #count number of non-censored timepoints
     num_timepoints = len(frame_mask)
@@ -488,7 +488,10 @@ def remove_trend(timeseries, frame_mask, order=1 , time_interval='0-end'):
     Y=timeseries
     W = closed_form(X[time_range, :],Y[time_range, :])
 
-    predicted = X.dot(W) #always subtract the trend over the whole timeseries
+    if remove_intercept:
+        predicted = X.dot(W) #always subtract the trend over the whole timeseries
+    else:
+        predicted = X[:,:-1].dot(W[:-1,:]) # only remove the trends, not the intercept
     residuals = (Y-predicted) # add back the intercept after
     fitted_intercept = W[-1,:] # predicted intercept
 

--- a/rabies/confound_correction_pkg/utils.py
+++ b/rabies/confound_correction_pkg/utils.py
@@ -457,7 +457,7 @@ def nuisance_regression(timeseries_vol, motion_regressors_array, TR, frame_mask,
 def remove_trend(timeseries, frame_mask=None, order=1 , time_interval='0-end', remove_intercept=True):
     '''The timeseries is already censored, we need to create a timeseries that is censored with the same time mask so that it matches'''
 
-    if not frame_mask: # create a mask including all frames if none is provided
+    if frame_mask is None: # create a mask including all frames if none is provided
         frame_mask = np.ones(timeseries.shape[0]).astype(bool)
         
     #count number of non-censored timepoints

--- a/rabies/confound_correction_pkg/utils.py
+++ b/rabies/confound_correction_pkg/utils.py
@@ -454,8 +454,12 @@ def nuisance_regression(timeseries_vol, motion_regressors_array, TR, frame_mask,
     return timeseries_vol, predicted_vol, predicted_random_vol, num_regressors, VE_temporal, VE_spatial, VE_total_ratio, cleaned_slice_l
 
 
-def remove_trend(timeseries, frame_mask, order=1 , time_interval='0-end', remove_intercept=True):
+def remove_trend(timeseries, frame_mask=None, order=1 , time_interval='0-end', remove_intercept=True):
     '''The timeseries is already censored, we need to create a timeseries that is censored with the same time mask so that it matches'''
+
+    if not frame_mask: # create a mask including all frames if none is provided
+        frame_mask = np.ones(timeseries.shape[0]).astype(bool)
+        
     #count number of non-censored timepoints
     num_timepoints = len(frame_mask)
 

--- a/rabies/parser.py
+++ b/rabies/parser.py
@@ -892,7 +892,7 @@ def get_parser():
             "image_scaling as the timeseries, so as to retain the proportion between the \n"
             "average and variance of timeseries.\n"
             "Because this parameter re-introduces the intercept from detrending, if the \n"
-            "trend was estimated over a specific time intervel with detrending_time_interval,\n"
+            "trend was estimated over a specific data subset with time_interval,\n"
             "the intercept is the average over that time interval.\n"
             "At the downstream analysis stage, the intercept is removed again since analysis\n" 
             "expects mean-centered data.\n"

--- a/rabies/parser.py
+++ b/rabies/parser.py
@@ -880,6 +880,24 @@ def get_parser():
             "(default: %(default)s)\n"
             "\n"
         )
+    confound_correction.add_argument(
+        '--keep_EPI_average', dest='keep_EPI_average', action='store_true',
+        help=
+            "This option allows to re-introduce the voxelwise average that was removed during\n"
+            "detrending at the end of confound correction, so that the original EPI background\n"
+            "intensity is preserved.\n"
+            "Specifically, the intercept that is calculated from the linear model during \n"
+            "detrending is re-introduced. This intercept is also subjected to the same \n"
+            "image_scaling as the timeseries, so as to retain the proportion between the \n"
+            "average and variance of timeseries.\n"
+            "Because this parameter re-introduces the intercept from detrending, if the \n"
+            "trend was estimated over a specific time intervel with detrending_time_interval,\n"
+            "the intercept is the average over that time interval.\n"
+            "At the downstream analysis stage, the intercept is removed again since analysis\n" 
+            "expects mean-centered data.\n"
+            "(default: %(default)s)\n"
+            "\n"
+        )
 
 
     ####Analysis

--- a/rabies/parser.py
+++ b/rabies/parser.py
@@ -702,10 +702,11 @@ def get_parser():
         '--detrending', type=str,
         default='order=1,time_interval=0-end',
         help=
-            "Detrend the voxel timeseries. \n"
+            "Parameters for voxelwise detrending of timeseries. Note that an intercept is also always fitted and \n"
+            "removed to derive mean-centered timeseries, even if no trend is fitted (with order=0). \n"
             "* order: Specify the polynomial order for detrending as a integer. \n"
             "*** 0 for no detrending, 1 for linear detrending, 2 for quadratic etc. \n"
-            "* time_interval: the time interval over which the trend is computed. \n "
+            "* time_interval: the time interval over which the trend and intercept are computed. \n "
             "Follow the syntax from --timeseries_interval to select a subset of frames. \n"
             "Note the trend is always subtracted from the whole timeseries. \n"
             "(default: %(default)s)\n"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--keep_EPI_average` flag to confound correction stage to optionally preserve the detrending intercept as background intensity.

* **Documentation**
  * Clarified detrending behavior in help text to indicate intercept is always fitted and removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/CoBrALab/RABIES/pull/495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->