### PR TITLE
Bump docs dependencies and drop dead ICA-AROMA requirements.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ sphinx-rtd-dark-mode
 sphinx-rtd-theme
 sphinxcontrib-bibtex
 sphinxcontrib-programoutput
-jinja2==3.1.1
-pillow==10.1.0
+jinja2==3.1.6
+pillow==12.3.0
 rabies==0.6.1
 traits<7.0

--- a/rabies/confound_correction_pkg/mod_ICA_AROMA/requirements.txt
+++ b/rabies/confound_correction_pkg/mod_ICA_AROMA/requirements.txt
@@ -1,8 +1,0 @@
-future
-matplotlib==2.2
-numpy==1.14
-pandas==0.23
-seaborn==0.9.0
-
-###added dependencies for rodent adaptation
-nibabel


### PR DESCRIPTION
Clears all 23 open Dependabot alerts on this repo. None were on a runtime path — 21 were in the ReadTheDocs build environment and 2 were in a file nothing reads.

## `docs/requirements.txt` — 21 alerts

| | from | to |
|---|---|---|
| `jinja2` | 3.1.1 | 3.1.6 |
| `pillow` | 10.1.0 | 12.3.0 |

Pillow 12.x requires Python >= 3.10, so `.readthedocs.yml` moves from Python 3.9 to 3.10, and `ubuntu-20.04` to `ubuntu-22.04` (the 20.04 image doesn't offer 3.10). Sphinx 5.0 still supports 3.10, so that pin is untouched.

## `rabies/confound_correction_pkg/mod_ICA_AROMA/requirements.txt` — 2 alerts

Deleted. It pinned `numpy==1.14` / `pandas==0.23` / `matplotlib==2.2` and **nothing referenced it**: not `setup.py`, not `rabies_environment.yml`, not the top-level `Dockerfile`, not `mod_ICA_AROMA/Dockerfile` (which installs numpy/scipy via `yum`). It came in with the vendored upstream ICA-AROMA package and documented a `python2.7 -m pip install` workflow.

The only mention left is a line in the vendored `mod_ICA_AROMA/README.md` describing that original Python 2.7 install. I left that README alone since it's upstream text, but it's now a dangling reference if you'd rather trim it.

## Verification

Built the docs in a clean Python 3.10 venv from the updated `docs/requirements.txt`:

```
pillow   12.3.0
jinja2   3.1.6
sphinx   5.0.0
rabies   0.6.1
traits   6.4.3

build succeeded.
```

## Note — not addressed here

Dependabot doesn't parse conda environment files, so `rabies_environment.yml` is unscanned. It's what users and the container actually get, and it pins `scikit-learn=0.24.1`, `pandas=1.2.4`, `nibabel=3.2.1`, `matplotlib=3.3.4` — all 2021. That's a compatibility exercise rather than a security patch, so it's deliberately out of scope for this PR, but it's the dependency surface that actually ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eAqGnoxyyiEzktoJEktZn