### PR TITLE
Ignore __pycache__, .venv, docs/_build and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 build/
 dist/
 rabies.egg-info/
+__pycache__/
+.venv/
+docs/_build/
+.DS_Store


### PR DESCRIPTION
Four untracked paths that show up in `git status` during normal local work:

- `__pycache__/` — from `pip install -e .`
- `.venv/` — uv/venv default location
- `docs/_build/` — sphinx output directory set in `docs/Makefile`
- `.DS_Store` — macOS Finder

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kdq57U3c4xpcRTXWhtpWrt