### PR TITLE
Stop publishing nightly and master container images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,10 +7,7 @@ name: Docker
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '31 1 * * *'
   push:
-    branches: [ "master" ]
     # Publish semver tags as releases.
     tags: [ '*.*.*' ]
   pull_request:
@@ -73,7 +70,7 @@ jobs:
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.ref_type == 'tag' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,10 +43,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
-      # Login against a Docker registry except on PR
+      # Login against a Docker registry only when publishing a tag
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
+        if: github.ref_type == 'tag'
         uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
@@ -76,28 +76,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      # Re-tag the latest release image as :latest so the GitHub Packages
-      # page always recommends :latest instead of :master
-      - name: Get latest release tag
-        id: latest-release
-        if: github.event_name != 'pull_request'
-        run: |
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            LATEST_TAG="${{ github.ref_name }}"
-          else
-            LATEST_TAG=$(gh release view --json tagName -q .tagName 2>/dev/null || true)
-          fi
-
-          if [ -n "$LATEST_TAG" ]; then
-            echo "tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Tag latest release as :latest
-        if: github.event_name != 'pull_request' && steps.latest-release.outputs.tag != ''
+      # Re-tag the release image as :latest so the GitHub Packages
+      # page always recommends :latest
+      - name: Tag release as :latest
+        if: github.ref_type == 'tag'
         run: |
           IMAGE_LOWER=$(echo "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" | tr '[:upper:]' '[:lower:]')
           docker buildx imagetools create \
-            "${IMAGE_LOWER}:${{ steps.latest-release.outputs.tag }}" \
+            "${IMAGE_LOWER}:${{ github.ref_name }}" \
             --tag "${IMAGE_LOWER}:latest"


### PR DESCRIPTION
## Summary

- Remove the nightly cron and the push-on-master trigger from the Docker workflow. Only semver tag pushes publish to ghcr.io now.
- Guard the image push on tag refs, so a manual `workflow_dispatch` on a branch builds but does not publish a branch-named image.
- PR builds and the `:latest` retag of the newest release are unchanged.

The existing `nightly` and `master` images on ghcr.io are being removed separately. Until this merges, the cron on master keeps running and can recreate them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbjzuSab2kesaLAq9wbw2B
