### PR TITLE
Implement analysis class

### DIFF
--- a/rabies/analysis_pkg/analysis_functions.py
+++ b/rabies/analysis_pkg/analysis_functions.py
@@ -1,96 +1,23 @@
 import numpy as np
-import SimpleITK as sitk
-from .analysis_math import vcorrcoef,closed_form
-
 
 '''
-seed-based FC
+SBC
 '''
 
-def seed_based_FC(CR_dict_file, maps_dict_file, seed_name):
-    import os
-    import numpy as np
-    import SimpleITK as sitk
-    import pathlib
-    from rabies.utils import recover_3D
-    from rabies.analysis_pkg.analysis_math import vcorrcoef
-
-    import pickle
-    with open(CR_dict_file, 'rb') as handle:
-        CR_data_dict = pickle.load(handle)
-    with open(maps_dict_file, 'rb') as handle:
-        maps_data_dict = pickle.load(handle)
-    bold_file = CR_data_dict['bold_file']
-    mask_file = maps_data_dict['mask_file']
-    timeseries = CR_data_dict['timeseries']
-    seed_arr_dict = maps_data_dict['seed_arr_dict']
-    roi_mask = seed_arr_dict[seed_name].astype(bool)
-
-    # extract the voxel timeseries within the mask, and take the mean ROI timeseries
-    seed_timeseries = timeseries[:,roi_mask].mean(axis=1)
-
-    corrs = vcorrcoef(timeseries.T, seed_timeseries)
-    corrs[np.isnan(corrs)] = 0
-
-    corr_map_img = recover_3D(mask_file, corrs)
-    filename_split = pathlib.Path(bold_file).name.rsplit(".nii")[0]
-    corr_map_file = os.path.abspath(
-        filename_split+'_'+seed_name+'_corr_map.nii.gz')
-    
-    sitk.WriteImage(corr_map_img, corr_map_file)
-
-    # also save the seed timecourse
-    import pandas as pd
-    seed_timecourse_csv = os.path.abspath(
-        filename_split+'_'+seed_name+'_timecourse.csv')
-    pd.DataFrame(seed_timeseries).to_csv(seed_timecourse_csv, header=False, index=False)
-
-    return corr_map_file,seed_timecourse_csv
-
+def compute_seed_FC(timeseries, seed_arr_dict):
+    from .analysis_math import vcorrcoef
+    SBC_dict = {}
+    for seed_name, roi_mask_vec in seed_arr_dict.items():
+        roi_mask = roi_mask_vec.astype(bool)
+        seed_timeseries = timeseries[:, roi_mask].mean(axis=1)
+        corrs = vcorrcoef(timeseries.T, seed_timeseries)
+        corrs[np.isnan(corrs)] = 0
+        SBC_dict[seed_name] = (corrs, seed_timeseries)
+    return SBC_dict
 
 '''
 FC matrix
 '''
-
-
-def run_FC_matrix(CR_dict_file,maps_dict_file, figure_format, roi_type='parcellated'):
-    import os
-    import pandas as pd
-    import SimpleITK as sitk
-    import numpy as np
-    import pathlib  # Better path manipulation
-    from rabies.analysis_pkg.analysis_functions import parcellated_FC_matrix, plot_matrix
-
-    import pickle
-    with open(CR_dict_file, 'rb') as handle:
-        CR_data_dict = pickle.load(handle)
-    with open(maps_dict_file, 'rb') as handle:
-        maps_data_dict = pickle.load(handle)
-
-
-    bold_file = CR_data_dict['bold_file']
-    filename_split = pathlib.Path(bold_file).name.rsplit(".nii")
-    figname = os.path.abspath(filename_split[0]+f'_FC_matrix.{figure_format}')
-    
-    timeseries = CR_data_dict['timeseries']
-    atlas_idx = maps_data_dict['atlas_idx']
-    roi_list = maps_data_dict['roi_list']
-
-    if roi_type == 'parcellated':
-        corr_matrix,roi_labels = parcellated_FC_matrix(timeseries, atlas_idx, roi_list)
-        matrix_df = pd.DataFrame(corr_matrix, index=roi_labels, columns=roi_labels)
-    elif roi_type == 'voxelwise':
-        corr_matrix = np.corrcoef(timeseries.T)
-        matrix_df = pd.DataFrame(corr_matrix)
-    else:
-        raise ValueError(
-            f"Invalid --ROI_type provided: {roi_type}. Must be either 'parcellated' or 'voxelwise.'")
-    plot_matrix(figname, corr_matrix)
-
-    data_file = os.path.abspath(filename_split[0]+'_FC_matrix.csv')
-    matrix_df.to_csv(data_file, sep=',')
-    return data_file, figname
-
 
 def parcellated_FC_matrix(sub_timeseries, atlas_idx, roi_list):
     
@@ -123,7 +50,6 @@ def plot_matrix(filename, corr_matrix):
 ICA
 '''
 
-
 def run_group_ICA(bold_file_list, mask_file, dim, random_seed, background_image, disableMigp=False):
     import os
     import pandas as pd
@@ -145,177 +71,50 @@ def run_group_ICA(bold_file_list, mask_file, dim, random_seed, background_image,
     return out_dir, IC_file
 
 
-def run_DR_ICA(CR_dict_file, maps_dict_file,network_weighting):
+'''
+NPR
+'''
+def compute_NPR(timeseries, prior_map_vectors, prior_bold_idx, optimize_NPR_dict,
+                NPR_temporal_comp, NPR_spatial_comp,
+                network_weighting, filename_split, figure_format):
     import os
-    import pandas as pd
-    import pathlib  # Better path manipulation
-    import SimpleITK as sitk
-    from rabies.utils import recover_4D
-    from rabies.analysis_pkg.analysis_math import dual_regression
+    from .analysis_math import spatiotemporal_prior_fit
 
-    import pickle
-    with open(CR_dict_file, 'rb') as handle:
-        CR_data_dict = pickle.load(handle)
-    with open(maps_dict_file, 'rb') as handle:
-        maps_data_dict = pickle.load(handle)
-    bold_file = CR_data_dict['bold_file']
-    mask_file = maps_data_dict['mask_file']
-    timeseries = CR_data_dict['timeseries']
-    prior_map_vectors = maps_data_dict['prior_map_vectors']
+    C_prior = prior_map_vectors[prior_bold_idx,:].T
 
-    filename_split = pathlib.Path(bold_file).name.rsplit(".nii")
+    if optimize_NPR_dict['apply']:
+        modeling,_,_,_,optimize_report_fig = spatiotemporal_fit_converge(timeseries,C_prior,
+                                    window_size=optimize_NPR_dict['window_size'],
+                                    min_prior_corr=optimize_NPR_dict['min_prior_corr'],
+                                    diff_thresh=optimize_NPR_dict['diff_thresh'],
+                                    max_iter=optimize_NPR_dict['max_iter'], 
+                                    compute_max=optimize_NPR_dict['compute_max'], 
+                                    gen_report=True)
+        optimize_report_file = os.path.abspath(f'{filename_split}_NPR_optimize.{figure_format}')
+        optimize_report_fig.savefig(optimize_report_file, bbox_inches='tight')
+    else:
+        if NPR_temporal_comp<1: # make sure there is no negative number
+            NPR_temporal_comp=0
+        if NPR_spatial_comp<1: # make sure there is no negative number
+            NPR_spatial_comp=0
+        modeling = spatiotemporal_prior_fit(timeseries, C_prior, num_W=NPR_temporal_comp, num_C=NPR_spatial_comp)
+        optimize_report_file=None
 
-    DR = dual_regression(prior_map_vectors, timeseries)
+    # put together the spatial and temporal extra components
+    W_extra = np.concatenate((modeling['W_spatial'],modeling['W_temporal']), axis=1)
 
     if network_weighting=='absolute':
-        DR_C = DR['C']*DR['S']
+        C_extra = np.concatenate((modeling['C_spatial']*modeling['S_spatial'],
+            modeling['C_temporal']*modeling['S_temporal']), axis=1)
+        C_fit = modeling['C_fitted_prior']*modeling['S_fitted_prior']
     elif network_weighting=='relative':
-        DR_C = DR['C']
+        C_extra = np.concatenate((modeling['C_spatial'],
+            modeling['C_temporal']), axis=1)
+        C_fit = modeling['C_fitted_prior']
     else:
         raise 
-
-    dual_regression_timecourse_csv = os.path.abspath(filename_split[0]+'_dual_regression_timecourse.csv')
-    pd.DataFrame(DR['W']).to_csv(dual_regression_timecourse_csv, header=False, index=False)
-
-    # save the subjects' IC maps as .nii file
-    DR_maps_filename = os.path.abspath(filename_split[0]+'_DR_maps.nii.gz')
-    sitk.WriteImage(recover_4D(mask_file, DR_C.T, bold_file), DR_maps_filename)
-    return DR_maps_filename, dual_regression_timecourse_csv
-
-
-from nipype.interfaces.base import (
-    traits, TraitedSpec, BaseInterfaceInputSpec,
-    File, BaseInterface
-)
-
-class NeuralPriorRecoveryInputSpec(BaseInterfaceInputSpec):
-    CR_dict_file = File(exists=True, mandatory=True, desc="Dictionary with prepared input matrices from confound correction.")
-    maps_dict_file = File(exists=True, mandatory=True, desc="Dictionary with prepared input matrices with brain maps and masks.")
-    prior_bold_idx = traits.List(desc="The index for the ICA components that correspond to bold sources.")
-    NPR_temporal_comp = traits.Int(
-        desc="number of data-driven temporal components to compute.")
-    NPR_spatial_comp = traits.Int(
-        desc="number of data-driven spatial components to compute.")
-    optimize_NPR_dict = traits.Dict(
-        desc="Dictionary with options for optimizing NPR convergence.")
-    network_weighting = traits.Str(
-        desc="Whether to derive absolute or relative (variance-normalized) network maps.")
-    figure_format = traits.Str(
-        desc="Select file format for figures.")
-
-class NeuralPriorRecoveryOutputSpec(TraitedSpec):
-    NPR_prior_timecourse_csv = File(
-        exists=True, desc=".csv with timecourses from the fitted prior sources.")
-    NPR_extra_timecourse_csv = File(
-        exists=True, desc=".csv with timecourses from the scan-specific extra sources.")
-    NPR_prior_filename = File(
-        exists=True, desc=".nii file with spatial components from the fitted prior sources.")
-    NPR_extra_filename = File(
-        exists=True, desc=".nii file with spatial components from the scan-specific extra sources.")
-    optimize_report = traits.Any(
-        exists=False, desc="The NPR optimization report.")
-
-
-class NeuralPriorRecovery(BaseInterface):
-    """
-
-    """
-
-    input_spec = NeuralPriorRecoveryInputSpec
-    output_spec = NeuralPriorRecoveryOutputSpec
-
-    def _run_interface(self, runtime):
-        import os
-        import numpy as np
-        import pandas as pd
-        import pathlib  # Better path manipulation
-        from rabies.utils import recover_4D
-        from rabies.analysis_pkg.analysis_math import spatiotemporal_prior_fit
-
-        import pickle
-        with open(self.inputs.CR_dict_file, 'rb') as handle:
-            CR_data_dict = pickle.load(handle)
-        with open(self.inputs.maps_dict_file, 'rb') as handle:
-            maps_data_dict = pickle.load(handle)
-        bold_file = CR_data_dict['bold_file']
-        mask_file = maps_data_dict['mask_file']
-        timeseries = CR_data_dict['timeseries']
-        prior_map_vectors = maps_data_dict['prior_map_vectors']
-        network_weighting=self.inputs.network_weighting
-
-        filename_split = pathlib.Path(
-            bold_file).name.rsplit(".nii")
-
-        C_prior = prior_map_vectors[self.inputs.prior_bold_idx,:].T
-
-        optimize_NPR_dict = self.inputs.optimize_NPR_dict
-        if optimize_NPR_dict['apply']:
-            modeling,_,_,_,optimize_report_fig = spatiotemporal_fit_converge(timeseries,C_prior,
-                                        window_size=optimize_NPR_dict['window_size'],
-                                        min_prior_corr=optimize_NPR_dict['min_prior_corr'],
-                                        diff_thresh=optimize_NPR_dict['diff_thresh'],
-                                        max_iter=optimize_NPR_dict['max_iter'], 
-                                        compute_max=optimize_NPR_dict['compute_max'], 
-                                        gen_report=True)
-            optimize_report_file = os.path.abspath(f'{filename_split[0]}_NPR_optimize.{self.inputs.figure_format}')
-            optimize_report_fig.savefig(optimize_report_file, bbox_inches='tight')
-        else:
-            NPR_temporal_comp = self.inputs.NPR_temporal_comp
-            NPR_spatial_comp = self.inputs.NPR_spatial_comp
-            if NPR_temporal_comp<1: # make sure there is no negative number
-                NPR_temporal_comp=0
-            if NPR_spatial_comp<1: # make sure there is no negative number
-                NPR_spatial_comp=0
-            modeling = spatiotemporal_prior_fit(timeseries, C_prior, num_W=NPR_temporal_comp, num_C=NPR_spatial_comp)
-            optimize_report_file=None
-
-        # put together the spatial and temporal extra components
-        W_extra = np.concatenate((modeling['W_spatial'],modeling['W_temporal']), axis=1)
-
-        if network_weighting=='absolute':
-            C_extra = np.concatenate((modeling['C_spatial']*modeling['S_spatial'],
-                modeling['C_temporal']*modeling['S_temporal']), axis=1)
-            C_fit = modeling['C_fitted_prior']*modeling['S_fitted_prior']
-        elif network_weighting=='relative':
-            C_extra = np.concatenate((modeling['C_spatial'],
-                modeling['C_temporal']), axis=1)
-            C_fit = modeling['C_fitted_prior']
-        else:
-            raise 
-
-        NPR_prior_timecourse_csv = os.path.abspath(filename_split[0]+'_NPR_prior_timecourse.csv')
-        pd.DataFrame(modeling['W_fitted_prior']).to_csv(NPR_prior_timecourse_csv, header=False, index=False)
-
-        NPR_extra_timecourse_csv = os.path.abspath(filename_split[0]+'_NPR_extra_timecourse.csv')
-        pd.DataFrame(W_extra).to_csv(NPR_extra_timecourse_csv, header=False, index=False)
-
-        NPR_prior_filename = os.path.abspath(filename_split[0]+'_NPR_prior.nii.gz')
-        sitk.WriteImage(recover_4D(mask_file,C_fit.T, bold_file), NPR_prior_filename)
-
-        if (self.inputs.NPR_temporal_comp+self.inputs.NPR_spatial_comp)>0:
-            NPR_extra_filename = os.path.abspath(filename_split[0]+'_NPR_extra.nii.gz')
-            sitk.WriteImage(recover_4D(mask_file,C_extra.T, bold_file), NPR_extra_filename)
-        else:
-            empty_img = sitk.GetImageFromArray(np.empty([1,1]))
-            empty_file = os.path.abspath('empty.nii.gz')
-            sitk.WriteImage(empty_img, empty_file)
-            NPR_extra_filename = empty_file
-
-        setattr(self, 'NPR_prior_timecourse_csv', NPR_prior_timecourse_csv)
-        setattr(self, 'NPR_extra_timecourse_csv', NPR_extra_timecourse_csv)
-        setattr(self, 'NPR_prior_filename', NPR_prior_filename)
-        setattr(self, 'NPR_extra_filename', NPR_extra_filename)
-        setattr(self, 'optimize_report', optimize_report_file)
-
-        return runtime
-
-    def _list_outputs(self):
-        return {'NPR_prior_timecourse_csv': getattr(self, 'NPR_prior_timecourse_csv'),
-                'NPR_extra_timecourse_csv': getattr(self, 'NPR_extra_timecourse_csv'),
-                'NPR_prior_filename': getattr(self, 'NPR_prior_filename'),
-                'NPR_extra_filename': getattr(self, 'NPR_extra_filename'),
-                'optimize_report': getattr(self, 'optimize_report'),
-                }
+    W_fit = modeling['W_fitted_prior']
+    return C_fit, W_fit, C_extra, W_extra, optimize_report_file
 
 
 def eval_convergence(prior_corr_list,fit_diff_list,window_size=5,min_prior_corr=0.5,diff_thresh=0.04):

--- a/rabies/analysis_pkg/analysis_wf.py
+++ b/rabies/analysis_pkg/analysis_wf.py
@@ -1,22 +1,31 @@
 import os
 import pathlib
+import numpy as np
+import pandas as pd
+import SimpleITK as sitk
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from nipype import Function
+from nipype.interfaces.base import (
+    traits, TraitedSpec, BaseInterfaceInputSpec,
+    File, BaseInterface
+)
 
 from rabies.utils import ResampleVolumes
-from .analysis_functions import run_group_ICA, run_DR_ICA, run_FC_matrix, seed_based_FC
+from .analysis_functions import run_group_ICA
 
 
-def init_analysis_wf(opts, name="analysis_wf"):
+def init_analysis_wf(analysis_opts, cr_opts, name="analysis_wf"):
 
     workflow = pe.Workflow(name=name)
     subject_inputnode = pe.Node(niu.IdentityInterface(
-        fields=['CR_dict_file', 'maps_dict_file', 'token', 'native_to_commonspace_transform_list', 'native_to_commonspace_inverse_list']), name='subject_inputnode')
+        fields=['cleaned_bold_file', 'name_source', 'CR_data_dict', 
+                'mask_file', 'anat_ref_file', 'to_analysis_space_transform_list', 'to_analysis_space_inverse_list',
+                'token', 'native_to_commonspace_transform_list', 'native_to_commonspace_inverse_list']), name='subject_inputnode')
     group_inputnode = pe.Node(niu.IdentityInterface(
         fields=['bold_file_list', 'commonspace_mask', 'commonspace_template', 'token']), name='group_inputnode')
     outputnode = pe.Node(niu.IdentityInterface(fields=['group_ICA_dir', 'IC_file', 'dual_regression_timecourse_csv',
-                                                       'DR_nii_file', 'DR_nii_file_resampled', 'matrix_data_file', 'matrix_fig', 'corr_map_file', 'corr_map_file_resampled', 'seed_timecourse_csv', 'joined_corr_map_file', 'joined_seed_timecourse_csv',
+                                                       'DR_nii_file', 'DR_nii_file_resampled', 'matrix_data_file', 'matrix_fig', 'corr_map_file_list', 'corr_map_file_resampled', 'seed_timecourse_csv_list',
                                                        'sub_token', 'group_token','NPR_prior_timecourse_csv', 'NPR_extra_timecourse_csv',
                                                        'NPR_prior_filename', 'NPR_extra_filename', 'NPR_optimize_report']), name='outputnode')
 
@@ -30,124 +39,126 @@ def init_analysis_wf(opts, name="analysis_wf"):
             ]),
         ])
 
-    if len(opts.seed_list) > 0:
-        seed_based_FC_node = pe.Node(Function(input_names=['CR_dict_file', 'maps_dict_file', 'seed_name'],
-                                              output_names=['corr_map_file', 'seed_timecourse_csv'],
-                                              function=seed_based_FC),
-                                     name='seed_based_FC', mem_gb=1*opts.scale_min_memory)
-        seed_based_FC_node.iterables = ('seed_name', opts.seed_name_list)
+    run_seed_FC = len(analysis_opts.seed_list) > 0
+    run_NPR = (analysis_opts.NPR_temporal_comp>-1) or (analysis_opts.NPR_spatial_comp>-1) or analysis_opts.optimize_NPR['apply']
 
-        # create a joinnode to provide also combined seed maps
-        seed_FC_joinnode = pe.JoinNode(niu.IdentityInterface(fields=['joined_corr_map_file', 'joined_seed_timecourse_csv']),
-                                                name='seed_FC_joinnode',
-                                                joinsource='seed_based_FC',
-                                                joinfield=['joined_corr_map_file', 'joined_seed_timecourse_csv'])
+    # a single node loads every input this scan's FC analyses need exactly once, and
+    # computes whichever of seed-based FC/dual regression/FC matrix/NPR were requested
+    if run_seed_FC or analysis_opts.DR_ICA or analysis_opts.FC_matrix or run_NPR:
 
+        FC_analysis_node = pe.Node(FCAnalysis(
+            analysis_opts=analysis_opts, cr_opts=cr_opts,
+            ), name='FC_analysis', mem_gb=1*analysis_opts.scale_min_memory)
 
         workflow.connect([
-            (subject_inputnode, seed_based_FC_node, [
-                ("CR_dict_file", "CR_dict_file"),
-                ("maps_dict_file", "maps_dict_file"),
-                ]),
-            (seed_based_FC_node, outputnode, [
-                ("corr_map_file", "corr_map_file"),
-                ("seed_timecourse_csv", "seed_timecourse_csv"),
-                ]),
-            (seed_based_FC_node, seed_FC_joinnode, [
-                ("seed_timecourse_csv", "joined_seed_timecourse_csv"),
-                ]),
-            (seed_FC_joinnode, outputnode, [
-                ("joined_corr_map_file", "joined_corr_map_file"),
-                ("joined_seed_timecourse_csv", "joined_seed_timecourse_csv"),
+            (subject_inputnode, FC_analysis_node, [
+                ("cleaned_bold_file", "cleaned_bold_file"),
+                ("name_source", "name_source"),
+                ("CR_data_dict", "CR_data_dict"),
+                ("mask_file", "mask_file"),
+                ("anat_ref_file", "anat_ref_file"),
+                ("to_analysis_space_transform_list", "to_analysis_space_transform_list"),
+                ("to_analysis_space_inverse_list", "to_analysis_space_inverse_list"),
                 ]),
             ])
 
-
-        if opts.resample_to_commonspace:
-            SBC_transform_node = pe.Node(ResampleVolumes(
-                resampling_dim='ref_file', interpolation=opts.interpolation_sitk,
-                rabies_data_type=opts.data_type, apply_motcorr=False, clip_negative=False), 
-                name='SBC_to_commonspace')
-            
+        if run_seed_FC:
             workflow.connect([
-                (subject_inputnode, SBC_transform_node, [
-                    ("native_to_commonspace_transform_list", "transforms_3d_files"),
-                    ("native_to_commonspace_inverse_list", "inverses_3d"),
-                    ]),
-                (group_inputnode, SBC_transform_node, [
-                    ("commonspace_template", "ref_file"),
-                    ]),
-                (seed_based_FC_node, SBC_transform_node, [
-                    ("corr_map_file", "in_file"),
-                    ("corr_map_file", "name_source"),
-                    ]),
-                (SBC_transform_node, outputnode, [
-                    ("resampled_file", "corr_map_file_resampled"),
-                    ]),
-                (SBC_transform_node, seed_FC_joinnode, [
-                    ("resampled_file", "joined_corr_map_file"),
-                    ]),
-                ])
-        else:
-            workflow.connect([
-                (seed_based_FC_node, seed_FC_joinnode, [
-                    ("corr_map_file", "joined_corr_map_file"),
+                (FC_analysis_node, outputnode, [
+                    ("corr_map_file_list", "corr_map_file_list"),
+                    ("seed_timecourse_csv_list", "seed_timecourse_csv_list"),
                     ]),
                 ])
 
+            if analysis_opts.resample_to_commonspace:
+                SBC_transform_node = pe.MapNode(ResampleVolumes(
+                    resampling_dim='ref_file', interpolation=analysis_opts.interpolation_sitk,
+                    rabies_data_type=analysis_opts.data_type, apply_motcorr=False, clip_negative=False),
+                    iterfield=['in_file', 'name_source'],
+                    name='SBC_to_commonspace')
 
+                workflow.connect([
+                    (subject_inputnode, SBC_transform_node, [
+                        ("native_to_commonspace_transform_list", "transforms_3d_files"),
+                        ("native_to_commonspace_inverse_list", "inverses_3d"),
+                        ]),
+                    (group_inputnode, SBC_transform_node, [
+                        ("commonspace_template", "ref_file"),
+                        ]),
+                    (FC_analysis_node, SBC_transform_node, [
+                        ("corr_map_file_list", "in_file"),
+                        ("corr_map_file_list", "name_source"),
+                        ]),
+                    (SBC_transform_node, outputnode, [
+                        ("resampled_file", "corr_map_file_resampled"),
+                        ]),
+                    ])
 
-    if opts.DR_ICA:
-
-        DR_ICA = pe.Node(Function(input_names=['CR_dict_file', 'maps_dict_file', 'network_weighting'],
-                                  output_names=['DR_maps_filename', 'dual_regression_timecourse_csv'],
-                                  function=run_DR_ICA),
-                         name='DR_ICA', mem_gb=1*opts.scale_min_memory)
-        DR_ICA.inputs.network_weighting = opts.network_weighting
-
-        workflow.connect([
-            (subject_inputnode, DR_ICA, [
-                ("CR_dict_file", "CR_dict_file"),
-                ("maps_dict_file", "maps_dict_file"),
-                ]),
-            (DR_ICA, outputnode, [
-                ("dual_regression_timecourse_csv", "dual_regression_timecourse_csv"),
-                ("DR_maps_filename", "DR_nii_file"),
-                ]),
-            ])
-
-        if opts.resample_to_commonspace:
-            DR_transform_node = pe.Node(ResampleVolumes(
-                resampling_dim='ref_file', interpolation=opts.interpolation_sitk,
-                rabies_data_type=opts.data_type, apply_motcorr=False, clip_negative=False), 
-                n_procs=int(os.environ['RABIES_ITK_NUM_THREADS']),
-                name='DR_to_commonspace')
-            
+        if analysis_opts.DR_ICA:
             workflow.connect([
-                (subject_inputnode, DR_transform_node, [
-                    ("native_to_commonspace_transform_list", "transforms_3d_files"),
-                    ("native_to_commonspace_inverse_list", "inverses_3d"),
-                    ]),
-                (group_inputnode, DR_transform_node, [
-                    ("commonspace_template", "ref_file"),
-                    ]),
-                (DR_ICA, DR_transform_node, [
-                    ("DR_maps_filename", "in_file"),
-                    ("DR_maps_filename", "name_source"),
-                    ]),
-                (DR_transform_node, outputnode, [
-                    ("resampled_file", "DR_nii_file_resampled"),
+                (FC_analysis_node, outputnode, [
+                    ("dual_regression_timecourse_csv", "dual_regression_timecourse_csv"),
+                    ("DR_maps_filename", "DR_nii_file"),
                     ]),
                 ])
 
-    if opts.group_ica['apply']:
+            if analysis_opts.resample_to_commonspace:
+                DR_transform_node = pe.Node(ResampleVolumes(
+                    resampling_dim='ref_file', interpolation=analysis_opts.interpolation_sitk,
+                    rabies_data_type=analysis_opts.data_type, apply_motcorr=False, clip_negative=False),
+                    n_procs=int(os.environ['RABIES_ITK_NUM_THREADS']),
+                    name='DR_to_commonspace')
+
+                workflow.connect([
+                    (subject_inputnode, DR_transform_node, [
+                        ("native_to_commonspace_transform_list", "transforms_3d_files"),
+                        ("native_to_commonspace_inverse_list", "inverses_3d"),
+                        ]),
+                    (group_inputnode, DR_transform_node, [
+                        ("commonspace_template", "ref_file"),
+                        ]),
+                    (FC_analysis_node, DR_transform_node, [
+                        ("DR_maps_filename", "in_file"),
+                        ("DR_maps_filename", "name_source"),
+                        ]),
+                    (DR_transform_node, outputnode, [
+                        ("resampled_file", "DR_nii_file_resampled"),
+                        ]),
+                    ])
+
+        if run_NPR:
+            workflow.connect([
+                (FC_analysis_node, outputnode, [
+                    ("NPR_prior_timecourse_csv", "NPR_prior_timecourse_csv"),
+                    ("NPR_extra_timecourse_csv", "NPR_extra_timecourse_csv"),
+                    ("NPR_prior_filename", "NPR_prior_filename"),
+                    ("NPR_extra_filename", "NPR_extra_filename"),
+                    ]),
+                ])
+
+            if analysis_opts.optimize_NPR['apply']:
+                workflow.connect([
+                    (FC_analysis_node, outputnode, [
+                        ("NPR_optimize_report", "NPR_optimize_report"),
+                        ]),
+                    ])
+
+        if analysis_opts.FC_matrix:
+            workflow.connect([
+                (FC_analysis_node, outputnode, [
+                    ("matrix_data_file", "matrix_data_file"),
+                    ("matrix_fig", "matrix_fig"),
+                    ]),
+                ])
+
+    if analysis_opts.group_ica['apply']:
         group_ICA = pe.Node(Function(input_names=['bold_file_list', 'mask_file', 'dim', 'random_seed', 'background_image', 'disableMigp'],
                                      output_names=['out_dir', 'IC_file'],
                                      function=run_group_ICA),
-                            name='group_ICA', mem_gb=1*opts.scale_min_memory)
-        group_ICA.inputs.dim = opts.group_ica['dim']
-        group_ICA.inputs.random_seed = opts.group_ica['random_seed']
-        group_ICA.inputs.disableMigp = opts.group_ica['disableMigp']
+                            name='group_ICA', mem_gb=1*analysis_opts.scale_min_memory)
+        group_ICA.inputs.dim = analysis_opts.group_ica['dim']
+        group_ICA.inputs.random_seed = analysis_opts.group_ica['random_seed']
+        group_ICA.inputs.disableMigp = analysis_opts.group_ica['disableMigp']
 
         workflow.connect([
             (group_inputnode, group_ICA, [
@@ -161,56 +172,393 @@ def init_analysis_wf(opts, name="analysis_wf"):
                 ]),
             ])
 
-    if (opts.NPR_temporal_comp>-1) or (opts.NPR_spatial_comp>-1) or opts.optimize_NPR['apply']:
-        from .analysis_functions import NeuralPriorRecovery
-
-        NPR_node = pe.Node(NeuralPriorRecovery(
-                            NPR_temporal_comp=opts.NPR_temporal_comp, 
-                            NPR_spatial_comp=opts.NPR_spatial_comp, 
-                            optimize_NPR_dict=opts.optimize_NPR, 
-                            prior_bold_idx = opts.prior_bold_idx,
-                            network_weighting=opts.network_weighting,
-                            figure_format=opts.figure_format),
-                            name='NPR_node', mem_gb=1*opts.scale_min_memory)
-
-        workflow.connect([
-            (subject_inputnode, NPR_node, [
-                ("CR_dict_file", "CR_dict_file"),
-                ("maps_dict_file", "maps_dict_file"),
-                ]),
-            (NPR_node, outputnode, [
-                ("NPR_prior_timecourse_csv", "NPR_prior_timecourse_csv"),
-                ("NPR_extra_timecourse_csv", "NPR_extra_timecourse_csv"),
-                ("NPR_prior_filename", "NPR_prior_filename"),
-                ("NPR_extra_filename", "NPR_extra_filename"),
-                ]),
-            ])
-        
-    if opts.optimize_NPR['apply']:
-        workflow.connect([
-            (NPR_node, outputnode, [
-                ("optimize_report", "NPR_optimize_report"),
-                ]),
-            ])
-
-
-    if opts.FC_matrix:
-        FC_matrix = pe.Node(Function(input_names=['CR_dict_file', 'maps_dict_file', 'figure_format', 'roi_type'],
-                                     output_names=['data_file', 'figname'],
-                                     function=run_FC_matrix),
-                            name='FC_matrix', mem_gb=1*opts.scale_min_memory)
-        FC_matrix.inputs.roi_type = opts.ROI_type
-        FC_matrix.inputs.figure_format = opts.figure_format
-
-        workflow.connect([
-            (subject_inputnode, FC_matrix, [
-                ("CR_dict_file", "CR_dict_file"),
-                ("maps_dict_file", "maps_dict_file"),
-                ]),
-            (FC_matrix, outputnode, [
-                ("data_file", "matrix_data_file"),
-                ("figname", "matrix_fig"),
-                ]),
-            ])
-
     return workflow
+
+
+class FCAnalysisInputSpec(BaseInterfaceInputSpec):
+    # confound correction outputs for this scan
+    cleaned_bold_file = File(exists=True, mandatory=True,
+        desc="Cleaned/confound-corrected 4D EPI timeseries for this scan, in the analysis space (native or commonspace).")
+    name_source = File(exists=True, mandatory=True,
+        desc="The original raw EPI file, used only to name outputs consistently with the rest of RABIES.")
+    CR_data_dict = traits.Dict(
+        desc="Confound correction info dict for this scan; only 'voxelwise_mean' is read from it, to undo the intercept re-added by --keep_EPI_average.")
+
+    # definition of the analysis space (native or commonspace, resolved by the caller)
+    mask_file = File(exists=True, mandatory=True, desc="Brain mask in the analysis space.")
+    anat_ref_file = File(exists=True, mandatory=True,
+        desc="Anatomical reference defining the analysis space, onto which priors/seeds/atlas are resampled.")
+    to_analysis_space_transform_list = traits.List([], usedefault=True,
+        desc="Transforms mapping priors/seeds/atlas (in their original commonspace) onto the analysis space. Empty if already in commonspace.")
+    to_analysis_space_inverse_list = traits.List([], usedefault=True,
+        desc="Booleans indicating which of to_analysis_space_transform_list must be applied as an inverse.")
+    analysis_opts = traits.Any(
+        exists=True, mandatory=True, desc="RABIES analysis parameters specs.")
+    cr_opts = traits.Any(
+        exists=True, mandatory=True, desc="RABIES confound correction parameters specs.")
+
+
+class FCAnalysisOutputSpec(TraitedSpec):
+    corr_map_file_list = traits.List(desc="Seed-based FC map for each seed in seed_dict.")
+    seed_timecourse_csv_list = traits.List(desc="Seed timecourse .csv for each seed in seed_dict.")
+    DR_maps_filename = traits.Any(desc=".nii file with the dual regression spatial maps.")
+    dual_regression_timecourse_csv = traits.Any(desc=".csv with the dual regression timecourses.")
+    matrix_data_file = traits.Any(desc=".csv with the FC matrix.")
+    matrix_fig = traits.Any(desc="Figure of the FC matrix.")
+    NPR_prior_timecourse_csv = traits.Any(desc=".csv with timecourses from the fitted prior sources.")
+    NPR_extra_timecourse_csv = traits.Any(desc=".csv with timecourses from the scan-specific extra sources.")
+    NPR_prior_filename = traits.Any(desc=".nii file with spatial components from the fitted prior sources.")
+    NPR_extra_filename = traits.Any(desc=".nii file with spatial components from the scan-specific extra sources.")
+    NPR_optimize_report = traits.Any(desc="The NPR optimization report.")
+
+
+class FCAnalysis(BaseInterface):
+    """
+    Central per-scan FC analysis. Reads the raw RABIES outputs for one scan once,
+    then computes every requested scan-level analysis -- seed-based FC, dual 
+    regression, FC matrix, NPR.
+    """
+
+    input_spec = FCAnalysisInputSpec
+    output_spec = FCAnalysisOutputSpec
+
+    def _run_interface(self, runtime):
+        from rabies.utils import recover_3D, recover_4D
+
+        analysis_opts = self.inputs.analysis_opts
+        cr_opts = self.inputs.cr_opts
+
+        seed_dict = {seed_name: seed_file for seed_file, seed_name in zip(analysis_opts.seed_list, analysis_opts.seed_name_list)}
+
+        SBC_out, DR_out, FC_matrix_df, NPR_out = fc_analysis(
+            self.inputs.cleaned_bold_file, self.inputs.name_source, self.inputs.mask_file, self.inputs.anat_ref_file, # minimal inputs
+            seed_dict=seed_dict, # SBC options
+            FC_matrix=analysis_opts.FC_matrix, atlas_file=analysis_opts.ROI_labels_file, ROI_type=analysis_opts.ROI_type, # FC matrix options
+            prior_maps=analysis_opts.prior_maps, prior_bold_idx=analysis_opts.prior_bold_idx, DR_ICA=analysis_opts.DR_ICA, network_weighting=analysis_opts.network_weighting, # prior/dual regression options
+            NPR_temporal_comp=analysis_opts.NPR_temporal_comp, NPR_spatial_comp=analysis_opts.NPR_spatial_comp, optimize_NPR_dict=analysis_opts.optimize_NPR, # NPR options
+            CR_data_dict=self.inputs.CR_data_dict, remove_EPI_avg=cr_opts.keep_EPI_average, # whether to remove the EPI average from the cleaned timeseries before analysis
+            to_analysis_space_transform_list=self.inputs.to_analysis_space_transform_list, to_analysis_space_inverse_list=self.inputs.to_analysis_space_inverse_list, interpolation=analysis_opts.interpolation_sitk, # resampling to a different space
+            rabies_data_type=analysis_opts.data_type, figure_format=analysis_opts.figure_format,
+            )
+
+
+        '''
+        Prepare output files
+        '''
+        filename_split = pathlib.Path(self.inputs.name_source).name.rsplit(".nii")[0]
+
+        corr_map_file_l = []
+        seed_timecourse_csv_l = []
+        if SBC_out is not None:
+            for seed_name, (corr_map, seed_timeseries) in SBC_out.items():
+                corr_map_img = recover_3D(self.inputs.mask_file, corr_map)
+                corr_map_file = os.path.abspath(f'{filename_split}_{seed_name}_corr_map.nii.gz')
+                sitk.WriteImage(corr_map_img, corr_map_file)
+
+                seed_timecourse_csv = os.path.abspath(f'{filename_split}_{seed_name}_timecourse.csv')
+                pd.DataFrame(seed_timeseries).to_csv(seed_timecourse_csv, header=False, index=False)
+
+                corr_map_file_l.append(corr_map_file)
+                seed_timecourse_csv_l.append(seed_timecourse_csv)
+
+        if DR_out is None:
+            DR_maps_filename = None
+            dual_regression_timecourse_csv = None
+        else:
+            DR_C, DR_W = DR_out
+            dual_regression_timecourse_csv = os.path.abspath(f'{filename_split}_dual_regression_timecourse.csv')
+            pd.DataFrame(DR_W).to_csv(dual_regression_timecourse_csv, header=False, index=False)
+
+            DR_maps_filename = os.path.abspath(f'{filename_split}_DR_maps.nii.gz')
+            sitk.WriteImage(recover_4D(self.inputs.mask_file, DR_C.T, self.inputs.cleaned_bold_file), DR_maps_filename)
+
+        if FC_matrix_df is not None:
+            from .analysis_functions import plot_matrix
+            matrix_fig = os.path.abspath(f'{filename_split}_FC_matrix.{analysis_opts.figure_format}')
+            plot_matrix(matrix_fig, FC_matrix_df.values)
+
+            matrix_data_file = os.path.abspath(f'{filename_split}_FC_matrix.csv')
+            FC_matrix_df.to_csv(matrix_data_file, sep=',')
+        else:
+            matrix_data_file = None
+            matrix_fig = None
+
+        if NPR_out is not None:
+            NPR_C_fit, NPR_W_fit, NPR_C_extra, NPR_W_extra, NPR_optimize_report = NPR_out
+            NPR_prior_timecourse_csv = os.path.abspath(filename_split+'_NPR_prior_timecourse.csv')
+            pd.DataFrame(NPR_W_fit).to_csv(NPR_prior_timecourse_csv, header=False, index=False)
+
+            NPR_extra_timecourse_csv = os.path.abspath(filename_split+'_NPR_extra_timecourse.csv')
+            pd.DataFrame(NPR_W_extra).to_csv(NPR_extra_timecourse_csv, header=False, index=False)
+
+            NPR_prior_filename = os.path.abspath(filename_split+'_NPR_prior.nii.gz')
+            sitk.WriteImage(recover_4D(self.inputs.mask_file,NPR_C_fit.T, self.inputs.cleaned_bold_file), NPR_prior_filename)
+
+            if (analysis_opts.NPR_temporal_comp+analysis_opts.NPR_spatial_comp)>0:
+                NPR_extra_filename = os.path.abspath(filename_split+'_NPR_extra.nii.gz')
+                sitk.WriteImage(recover_4D(self.inputs.mask_file,NPR_C_extra.T, self.inputs.cleaned_bold_file), NPR_extra_filename)
+            else:
+                empty_img = sitk.GetImageFromArray(np.empty([1,1]))
+                empty_file = os.path.abspath('empty.nii.gz')
+                sitk.WriteImage(empty_img, empty_file)
+                NPR_extra_filename = empty_file
+        else:
+            NPR_prior_timecourse_csv = None
+            NPR_extra_timecourse_csv = None
+            NPR_prior_filename = None
+            NPR_extra_filename = None
+            NPR_optimize_report = None
+
+
+        setattr(self, 'corr_map_file_list', corr_map_file_l)
+        setattr(self, 'seed_timecourse_csv_list', seed_timecourse_csv_l)
+        setattr(self, 'DR_maps_filename', DR_maps_filename)
+        setattr(self, 'dual_regression_timecourse_csv', dual_regression_timecourse_csv)
+        setattr(self, 'matrix_data_file', matrix_data_file)
+        setattr(self, 'matrix_fig', matrix_fig)
+        setattr(self, 'NPR_prior_timecourse_csv', NPR_prior_timecourse_csv)
+        setattr(self, 'NPR_extra_timecourse_csv', NPR_extra_timecourse_csv)
+        setattr(self, 'NPR_prior_filename', NPR_prior_filename)
+        setattr(self, 'NPR_extra_filename', NPR_extra_filename)
+        setattr(self, 'NPR_optimize_report', NPR_optimize_report)
+
+
+        return runtime
+
+
+    def _list_outputs(self):
+        return {
+            'corr_map_file_list': getattr(self, 'corr_map_file_list', []),
+            'seed_timecourse_csv_list': getattr(self, 'seed_timecourse_csv_list', []),
+            'DR_maps_filename': getattr(self, 'DR_maps_filename', None),
+            'dual_regression_timecourse_csv': getattr(self, 'dual_regression_timecourse_csv', None),
+            'matrix_data_file': getattr(self, 'matrix_data_file', None),
+            'matrix_fig': getattr(self, 'matrix_fig', None),
+            'NPR_prior_timecourse_csv': getattr(self, 'NPR_prior_timecourse_csv', None),
+            'NPR_extra_timecourse_csv': getattr(self, 'NPR_extra_timecourse_csv', None),
+            'NPR_prior_filename': getattr(self, 'NPR_prior_filename', None),
+            'NPR_extra_filename': getattr(self, 'NPR_extra_filename', None),
+            'NPR_optimize_report': getattr(self, 'NPR_optimize_report', None),
+        }
+
+
+
+def fc_analysis(
+    cleaned_bold_file, name_source, mask_file, anat_ref_file, # minimal inputs
+    seed_dict={}, # SBC options
+    FC_matrix=False, atlas_file=None, ROI_type='parcellated', # FC matrix options
+    prior_maps=None, prior_bold_idx=[], DR_ICA=False, network_weighting='absolute', # prior/dual regression options
+    NPR_temporal_comp=-1, NPR_spatial_comp=-1, optimize_NPR_dict={'apply': False}, # NPR options
+    CR_data_dict={}, remove_EPI_avg=False, # whether to remove the EPI average from the cleaned timeseries before analysis
+    to_analysis_space_transform_list=[], to_analysis_space_inverse_list=[], interpolation=sitk.sitkLinear, # resampling to a different space
+    rabies_data_type=sitk.sitkFloat32, figure_format='png',
+    ):
+    """
+    Core function for computing scan-level FC analyses -- seed-based connectivity (SBC),
+    dual regression (DR), an FC matrix, and/or neural prior recovery (NPR) -- from a single
+    load of a scan's cleaned timeseries and reference maps. Each analysis is only run if
+    its trigger parameters are set; otherwise its corresponding output is None.
+
+    Parameters
+    ----------
+
+    cleaned_bold_file : filepath
+        Cleaned/confound-corrected 4D EPI timeseries for this scan, in the analysis space
+        (native or commonspace).
+
+    name_source : filepath
+        The original raw EPI file, used only to name intermediate outputs consistently
+        with the rest of RABIES.
+
+    mask_file : filepath
+        Brain mask in the analysis space.
+
+    anat_ref_file : filepath
+        Anatomical reference defining the analysis space, onto which seed_dict/prior_maps/
+        atlas_file are resampled.
+
+    seed_dict : dict, default={}
+        Dictionary of seed_name:seed_file pairs to compute SBC for. If empty, SBC is
+        skipped.
+
+    FC_matrix : bool, default=False
+        Whether to compute a whole-brain FC matrix.
+
+    atlas_file : filepath, default=None
+        Parcellation file, required for a parcellated (ROI_type='parcellated') FC matrix.
+
+    ROI_type : str, default='parcellated'
+        Either 'parcellated' or 'voxelwise' FC matrix.
+
+    prior_maps : filepath, default=None
+        4D file of network priors, required for DR_ICA and NPR.
+
+    prior_bold_idx : list, default=[]
+        Indices among prior_maps corresponding to BOLD sources, fitted during NPR.
+
+    DR_ICA : bool, default=False
+        Whether to compute dual regression against prior_maps.
+
+    network_weighting : str, default='absolute'
+        Whether DR/NPR network maps are 'absolute' or 'relative' (variance-normalized).
+
+    NPR_temporal_comp : int, default=-1
+        Number of data-driven temporal components for NPR. If this and NPR_spatial_comp
+        are both <0 and optimize_NPR_dict['apply'] is False, NPR is skipped.
+
+    NPR_spatial_comp : int, default=-1
+        Number of data-driven spatial components for NPR.
+
+    optimize_NPR_dict : dict, default={'apply': False}
+        Options for automatically optimizing NPR convergence instead of using fixed
+        NPR_temporal_comp/NPR_spatial_comp counts.
+
+    CR_data_dict : dict, default={}
+        Confound correction info dict for this scan; only 'voxelwise_mean' is read from
+        it, and only if remove_EPI_avg is True.
+
+    remove_EPI_avg : bool, default=False
+        Whether the voxelwise average was kept in the cleaned timeseries
+        (--keep_EPI_average) and must be subtracted back out, using
+        CR_data_dict['voxelwise_mean'], prior to analysis.
+
+    to_analysis_space_transform_list : list, default=[]
+        Transforms mapping seed_dict/prior_maps/atlas_file, in their original commonspace,
+        onto the analysis space. Empty if already in commonspace.
+
+    to_analysis_space_inverse_list : list, default=[]
+        Booleans indicating which of to_analysis_space_transform_list must be applied as an inverse.
+
+    interpolation : SimpleITK interpolator, default=sitk.sitkLinear
+        Interpolator used to resample prior_maps.
+
+    rabies_data_type : SimpleITK pixel type, default=sitk.sitkFloat32
+        Data type used for resampling.
+
+    figure_format : str, default='png'
+        File format for the NPR optimization report figure.
+
+    Returns
+    -------
+
+    SBC_out : dict or None
+        {seed_name: (corr_map, seed_timeseries)} for each seed in seed_dict, or None if
+        seed_dict is empty.
+
+    DR_out : tuple or None
+        (DR_C, DR_W), the dual regression spatial maps and timecourses, or None if DR_ICA
+        is False.
+
+    FC_matrix_df : pd.DataFrame or None
+        The FC matrix, or None if FC_matrix is False.
+
+    NPR_out : tuple or None
+        (C_fit, W_fit, C_extra, W_extra, optimize_report_file), the NPR fitted-prior and
+        extra components, or None if NPR wasn't requested.
+    """
+    from .analysis_math import dual_regression
+    from .analysis_functions import compute_seed_FC, parcellated_FC_matrix, compute_NPR
+
+    filename_split = pathlib.Path(name_source).name.rsplit(".nii")[0]
+
+    timeseries, seed_arr_dict, prior_map_vectors, atlas_idx, roi_list = load_analysis_inputs(
+        cleaned_bold_file, mask_file, anat_ref_file,
+        to_analysis_space_transform_list, to_analysis_space_inverse_list, seed_dict, prior_maps, atlas_file, 
+        remove_EPI_avg, CR_data_dict,
+        interpolation, rabies_data_type, output_prefix=filename_split,
+        )
+
+    '''
+    FC computations
+    '''
+    if len(seed_arr_dict.keys())>0:
+        SBC_out = compute_seed_FC(timeseries, seed_arr_dict)
+    else:
+        SBC_out = None
+
+    if DR_ICA:
+        DR = dual_regression(prior_map_vectors, timeseries)
+        if network_weighting == 'absolute':
+            DR_C = DR['C'] * DR['S']
+        elif network_weighting == 'relative':
+            DR_C = DR['C']
+        else:
+            raise ValueError(f"Invalid network_weighting: {network_weighting}")
+        DR_out = (DR_C, DR['W'])
+    else:
+        DR_out = None
+
+
+    if not FC_matrix:
+        FC_matrix_df = None
+    else:
+        if ROI_type == 'parcellated':
+            corr_matrix, roi_labels = parcellated_FC_matrix(timeseries, atlas_idx, roi_list)
+            FC_matrix_df = pd.DataFrame(corr_matrix, index=roi_labels, columns=roi_labels)
+        elif ROI_type == 'voxelwise':
+            corr_matrix = np.corrcoef(timeseries.T)
+            FC_matrix_df = pd.DataFrame(corr_matrix)
+        else:
+            raise ValueError(f"Invalid --ROI_type provided: {ROI_type}. Must be either 'parcellated' or 'voxelwise.'")
+
+
+    run_NPR = (NPR_temporal_comp > -1) or (NPR_spatial_comp > -1) or optimize_NPR_dict['apply']
+    if run_NPR:
+        NPR_C_fit, NPR_W_fit, NPR_C_extra, NPR_W_extra, NPR_optimize_report = compute_NPR(
+            timeseries, prior_map_vectors, prior_bold_idx, optimize_NPR_dict, 
+            NPR_temporal_comp, NPR_spatial_comp, 
+            network_weighting, filename_split, figure_format,
+            )
+        NPR_out = (NPR_C_fit, NPR_W_fit, NPR_C_extra, NPR_W_extra, NPR_optimize_report)
+    else:
+        NPR_out = None
+    return SBC_out, DR_out, FC_matrix_df, NPR_out
+
+
+def load_analysis_inputs(cleaned_bold_file, mask_file, anat_ref_file,
+                         transform_list=[], inverse_list=[], seed_dict={}, prior_maps=None, atlas_file=None, 
+                         remove_EPI_avg=False, CR_data_dict={},
+                         interpolation=sitk.sitkLinear, rabies_data_type=sitk.sitkFloat32, output_prefix=''):
+    '''
+    Load all the NIfTI inputs into vectorized, masked array format
+    in overlapping space with the timeseries.
+    '''
+    from rabies.utils import resample_volumes, antsApplyTransforms
+
+    mask_array = sitk.GetArrayFromImage(sitk.ReadImage(mask_file))
+    volume_indices = mask_array.astype(bool)
+    timeseries = sitk.GetArrayFromImage(sitk.ReadImage(cleaned_bold_file))[:, volume_indices]
+    if remove_EPI_avg:
+        timeseries = timeseries - CR_data_dict['voxelwise_mean']
+
+
+    seed_arr_dict = {}
+    for seed_name, seed_file in seed_dict.items():
+        resampled_seed_file = os.path.abspath(f'{output_prefix}_{seed_name}_resampled.nii.gz')
+        antsApplyTransforms(transforms=transform_list, inverses=inverse_list,
+            input_image=seed_file, ref_image=anat_ref_file, output_filename=resampled_seed_file,
+            interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
+        seed_arr_dict[seed_name] = sitk.GetArrayFromImage(sitk.ReadImage(resampled_seed_file))[volume_indices]
+
+    prior_map_vectors = None
+    if prior_maps is not None:
+        resampled_4D_img = resample_volumes(in_img=prior_maps, in_ref=anat_ref_file,
+            transforms_3d_files=transform_list, inverses_3d=inverse_list, motcorr_params_file=None,
+            interpolation=interpolation, rabies_data_type=rabies_data_type, clip_negative=False)
+        prior_map_vectors = sitk.GetArrayFromImage(resampled_4D_img)[:, volume_indices]
+
+    atlas_idx = None
+    roi_list = None
+    if atlas_file is not None:
+        resampled_atlas_file = os.path.abspath(f'{output_prefix}_atlas_resampled.nii.gz')
+        antsApplyTransforms(transforms=transform_list, inverses=inverse_list,
+            input_image=atlas_file, ref_image=anat_ref_file, output_filename=resampled_atlas_file,
+            interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
+        atlas_idx = sitk.GetArrayFromImage(sitk.ReadImage(resampled_atlas_file))[volume_indices]
+
+        # original (unresampled) atlas defines which ROI integers are present
+        atlas_data = sitk.GetArrayFromImage(sitk.ReadImage(str(atlas_file))).astype(int)
+        roi_list = [i for i in range(1, atlas_data.max() + 1) if np.max(i == atlas_data)]
+
+    return timeseries, seed_arr_dict, prior_map_vectors, atlas_idx, roi_list
+

--- a/rabies/analysis_pkg/analysis_wf.py
+++ b/rabies/analysis_pkg/analysis_wf.py
@@ -458,15 +458,22 @@ def fc_analysis(
     """
     from .analysis_math import dual_regression
     from .analysis_functions import compute_seed_FC, parcellated_FC_matrix, compute_NPR
+    from .utils import load_resample_analysis_maps
 
     filename_split = pathlib.Path(name_source).name.rsplit(".nii")[0]
 
-    timeseries, seed_arr_dict, prior_map_vectors, atlas_idx, roi_list = load_analysis_inputs(
-        cleaned_bold_file, mask_file, anat_ref_file,
-        to_analysis_space_transform_list, to_analysis_space_inverse_list, seed_dict, prior_maps, atlas_file, 
-        remove_EPI_avg, CR_data_dict,
-        interpolation, rabies_data_type, output_prefix=filename_split,
+    loaded = load_resample_analysis_maps(
+        mask_file, anat_ref_file,
+        transform_list=to_analysis_space_transform_list, inverse_list=to_analysis_space_inverse_list,
+        seed_dict=seed_dict, prior_maps=prior_maps, atlas_file=atlas_file,
+        cleaned_bold_file=cleaned_bold_file, CR_data_dict=CR_data_dict, remove_EPI_avg=remove_EPI_avg,
+        interpolation=interpolation, rabies_data_type=rabies_data_type, output_prefix=filename_split,
         )
+    timeseries = loaded['timeseries']
+    seed_arr_dict = loaded['seed_arr_dict']
+    prior_map_vectors = loaded['prior_map_vectors']
+    atlas_idx = loaded['atlas_idx']
+    roi_list = loaded['roi_list']
 
     '''
     FC computations
@@ -513,52 +520,4 @@ def fc_analysis(
     else:
         NPR_out = None
     return SBC_out, DR_out, FC_matrix_df, NPR_out
-
-
-def load_analysis_inputs(cleaned_bold_file, mask_file, anat_ref_file,
-                         transform_list=[], inverse_list=[], seed_dict={}, prior_maps=None, atlas_file=None, 
-                         remove_EPI_avg=False, CR_data_dict={},
-                         interpolation=sitk.sitkLinear, rabies_data_type=sitk.sitkFloat32, output_prefix=''):
-    '''
-    Load all the NIfTI inputs into vectorized, masked array format
-    in overlapping space with the timeseries.
-    '''
-    from rabies.utils import resample_volumes, antsApplyTransforms
-
-    mask_array = sitk.GetArrayFromImage(sitk.ReadImage(mask_file))
-    volume_indices = mask_array.astype(bool)
-    timeseries = sitk.GetArrayFromImage(sitk.ReadImage(cleaned_bold_file))[:, volume_indices]
-    if remove_EPI_avg:
-        timeseries = timeseries - CR_data_dict['voxelwise_mean']
-
-
-    seed_arr_dict = {}
-    for seed_name, seed_file in seed_dict.items():
-        resampled_seed_file = os.path.abspath(f'{output_prefix}_{seed_name}_resampled.nii.gz')
-        antsApplyTransforms(transforms=transform_list, inverses=inverse_list,
-            input_image=seed_file, ref_image=anat_ref_file, output_filename=resampled_seed_file,
-            interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
-        seed_arr_dict[seed_name] = sitk.GetArrayFromImage(sitk.ReadImage(resampled_seed_file))[volume_indices]
-
-    prior_map_vectors = None
-    if prior_maps is not None:
-        resampled_4D_img = resample_volumes(in_img=prior_maps, in_ref=anat_ref_file,
-            transforms_3d_files=transform_list, inverses_3d=inverse_list, motcorr_params_file=None,
-            interpolation=interpolation, rabies_data_type=rabies_data_type, clip_negative=False)
-        prior_map_vectors = sitk.GetArrayFromImage(resampled_4D_img)[:, volume_indices]
-
-    atlas_idx = None
-    roi_list = None
-    if atlas_file is not None:
-        resampled_atlas_file = os.path.abspath(f'{output_prefix}_atlas_resampled.nii.gz')
-        antsApplyTransforms(transforms=transform_list, inverses=inverse_list,
-            input_image=atlas_file, ref_image=anat_ref_file, output_filename=resampled_atlas_file,
-            interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
-        atlas_idx = sitk.GetArrayFromImage(sitk.ReadImage(resampled_atlas_file))[volume_indices]
-
-        # original (unresampled) atlas defines which ROI integers are present
-        atlas_data = sitk.GetArrayFromImage(sitk.ReadImage(str(atlas_file))).astype(int)
-        roi_list = [i for i in range(1, atlas_data.max() + 1) if np.max(i == atlas_data)]
-
-    return timeseries, seed_arr_dict, prior_map_vectors, atlas_idx, roi_list
 

--- a/rabies/analysis_pkg/diagnosis_pkg/diagnosis_functions.py
+++ b/rabies/analysis_pkg/diagnosis_pkg/diagnosis_functions.py
@@ -2,35 +2,35 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 from rabies.utils import recover_3D
-from rabies.analysis_pkg import analysis_functions
+from rabies.analysis_pkg.analysis_math import vcorrcoef
 import SimpleITK as sitk
 from .dataset_QC import masked_plot, threshold_top_percent
 
-def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_maps_data_dict, analysis_files_dict, 
-                                    prior_bold_idx, prior_confound_idx,
-                                    nativespace_analysis=False,resampling_specs=None,
+def compute_spatiotemporal_features(name_source, CR_data_dict, VE_spatial, temporal_std, predicted_std,
+                                    sub_mask_file, sub_space_maps_loaded, common_mask_file, common_anat_ref_file,
+                                    analysis_files_dict, prior_bold_idx, prior_confound_idx,
+                                    nativespace_analysis=False, resampling_specs=None,
                                     ):
     if resampling_specs is None:
         resampling_specs={}
-    # sub_maps_data_dict is the maps_data_dict that overlaps with the subject, either in native or common space depending on confound correction
-    # common_maps_data_dict contains files in commonspace
+    # sub_space_maps_loaded is load_resample_analysis_maps()'s output that overlaps with the subject, either in native or common space depending on confound correction
+    # commonspace_maps_loaded contains the same, but always in commonspace
     temporal_info = {}
     spatial_info = {}
-    temporal_info['name_source'] = CR_data_dict['name_source']
-    spatial_info['name_source'] = CR_data_dict['name_source']
+    temporal_info['name_source'] = name_source
+    spatial_info['name_source'] = name_source
+
+    # this timeseries can be in nativespace or commonspace depending on confound correction stage
+    timeseries = sub_space_maps_loaded['timeseries']
+
     # spatial maps will always be in commonspace for display
-    spatial_info['mask_file'] = common_maps_data_dict['mask_file']
+    spatial_info['mask_file'] = common_mask_file
+    commonspace_volume_indices = sitk.GetArrayFromImage(sitk.ReadImage(common_mask_file)).astype(bool)
 
-    # these timeseries can be in nativespace or commonspace depending on confound correction stage
-    timeseries = CR_data_dict['timeseries']
-    volume_indices = common_maps_data_dict['volume_indices']
-
-    CR_CR_data_dict = CR_data_dict['CR_data_dict']
-
-    temporal_info['FD_trace'] = CR_CR_data_dict['FD_trace']
-    temporal_info['DVARS_pre_correction'] = CR_CR_data_dict['DVARS_pre_correction']
-    temporal_info['mse_trace'] = CR_CR_data_dict['mse_trace']
-    temporal_info['VE_temporal'] = CR_CR_data_dict['VE_temporal']
+    temporal_info['FD_trace'] = CR_data_dict['FD_trace']
+    temporal_info['DVARS_pre_correction'] = CR_data_dict['DVARS_pre_correction']
+    temporal_info['mse_trace'] = CR_data_dict['mse_trace']
+    temporal_info['VE_temporal'] = CR_data_dict['VE_temporal']
 
 
     ### SBC analysis
@@ -38,7 +38,7 @@ def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_map
         seed_list=[]
         for seed_map in analysis_files_dict['seed_map_files']:
             seed_list.append(np.asarray(
-                sitk.GetArrayFromImage(sitk.ReadImage(seed_map)))[volume_indices])
+                sitk.GetArrayFromImage(sitk.ReadImage(seed_map)))[commonspace_volume_indices])
         spatial_info['seed_map_list'] = seed_list
         time_list=[]
         for time_csv in analysis_files_dict['seed_timecourse_csv']:
@@ -55,9 +55,9 @@ def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_map
             sitk.ReadImage(analysis_files_dict['dual_regression_nii']))
         if len(DR_array.shape)==3: # if there was only one component, need to convert to 4D array
             DR_array = DR_array[np.newaxis,:,:,:]
-        DR_C = np.zeros([DR_array.shape[0], volume_indices.sum()])
+        DR_C = np.zeros([DR_array.shape[0], commonspace_volume_indices.sum()])
         for i in range(DR_array.shape[0]):
-            DR_C[i, :] = (DR_array[i, :, :, :])[volume_indices]
+            DR_C[i, :] = (DR_array[i, :, :, :])[commonspace_volume_indices]
 
         temporal_info['DR_all'] = DR_W
         temporal_info['DR_bold'] = DR_W[:, prior_bold_idx]
@@ -74,22 +74,20 @@ def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_map
     '''Temporal Features'''
     global_signal = timeseries.mean(axis=1)
     temporal_info['global_signal'] = global_signal
-    temporal_info['predicted_time'] = CR_CR_data_dict['predicted_time']
+    temporal_info['predicted_time'] = CR_data_dict['predicted_time']
     # take regional timecourse by taking the RMS each 3D volume
-    edge_idx = sub_maps_data_dict['edge_idx']
+    edge_idx = sub_space_maps_loaded['edge_idx']
     #edge_trace = np.sqrt((timeseries.T[edge_idx]**2).mean(axis=0))
     edge_trace = timeseries[:,edge_idx].mean(axis=1)
     temporal_info['edge_trace'] = edge_trace
-    if sub_maps_data_dict['WM_idx'] is not None:
-        WM_idx = sub_maps_data_dict['WM_idx']
-        #WM_trace = np.sqrt((timeseries.T[WM_idx]**2).mean(axis=0))
+    if sub_space_maps_loaded['WM_idx'] is not None:
+        WM_idx = sub_space_maps_loaded['WM_idx']
         WM_trace = timeseries[:,WM_idx].mean(axis=1)
         temporal_info['WM_trace'] = WM_trace
     else:
         temporal_info['WM_trace'] = None
-    if sub_maps_data_dict['CSF_idx'] is not None:
-        CSF_idx = sub_maps_data_dict['CSF_idx']
-        #CSF_trace = np.sqrt((timeseries.T[CSF_idx]**2).mean(axis=0))
+    if sub_space_maps_loaded['CSF_idx'] is not None:
+        CSF_idx = sub_space_maps_loaded['CSF_idx']
         CSF_trace = timeseries[:,CSF_idx].mean(axis=1)
         temporal_info['CSF_trace'] = CSF_trace
     else:
@@ -97,7 +95,7 @@ def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_map
 
     '''Spatial Features'''
     GS_cov = (global_signal.reshape(-1,1)*timeseries).mean(axis=0) # calculate the covariance between global signal and each voxel
-    GS_corr = analysis_functions.vcorrcoef(timeseries.T, global_signal)
+    GS_corr = vcorrcoef(timeseries.T, global_signal)
 
     prior_fit_out = {'C': None, 'W': None}
     if not analysis_files_dict['NPR_prior_filename'] is None:
@@ -107,9 +105,9 @@ def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_map
         if len(C_array.shape)==3: # if there was only one component, need to convert to 4D array
             C_array = C_array[np.newaxis,:,:,:]
 
-        C = np.zeros([C_array.shape[0], volume_indices.sum()])
+        C = np.zeros([C_array.shape[0], commonspace_volume_indices.sum()])
         for i in range(C_array.shape[0]):
-            C[i, :] = (C_array[i, :, :, :])[volume_indices]
+            C[i, :] = (C_array[i, :, :, :])[commonspace_volume_indices]
         prior_fit_out['C'] = C
 
     if nativespace_analysis: # certain spatial maps were computed in nativespace and need resampling
@@ -117,27 +115,19 @@ def compute_spatiotemporal_features(CR_data_dict, sub_maps_data_dict, common_map
         import tempfile
         tmppath = tempfile.mkdtemp()
         def resample_brain_map(brain_map):
-            image_3d = recover_3D(sub_maps_data_dict['mask_file'], brain_map)
-            resampled_img = resample_volumes(image_3d, common_maps_data_dict['anat_ref_file'], 
-                                             transforms_3d_files=resampling_specs['transforms'], inverses_3d=resampling_specs['inverses'], 
-                                             motcorr_params_file = None, interpolation=resampling_specs['interpolation'], 
+            image_3d = recover_3D(sub_mask_file, brain_map)
+            resampled_img = resample_volumes(image_3d, common_anat_ref_file,
+                                             transforms_3d_files=resampling_specs['transforms'], inverses_3d=resampling_specs['inverses'],
+                                             motcorr_params_file = None, interpolation=resampling_specs['interpolation'],
                                              rabies_data_type=resampling_specs['rabies_data_type'], clip_negative=False)
-            resampled_brain_map = sitk.GetArrayFromImage(resampled_img)[common_maps_data_dict['volume_indices']]
+            resampled_brain_map = sitk.GetArrayFromImage(resampled_img)[commonspace_volume_indices]
             return resampled_brain_map
-            
+
         [GS_cov, GS_corr, VE_spatial, temporal_std, predicted_std] = [
-            resample_brain_map(brain_map) for brain_map in [GS_cov, GS_corr, CR_data_dict['VE_spatial'], 
-                                                            CR_data_dict['temporal_std'],CR_data_dict['predicted_std']]
+            resample_brain_map(brain_map) for brain_map in [GS_cov, GS_corr, VE_spatial, temporal_std, predicted_std]
             ]
         import shutil
         shutil.rmtree(tmppath, ignore_errors=True)
-    else:
-        VE_spatial, temporal_std, predicted_std = [CR_data_dict['VE_spatial'], CR_data_dict['temporal_std'],CR_data_dict['predicted_std']]
-
-    if common_maps_data_dict['prior_map_vectors'] is not None:
-        spatial_info['prior_maps'] = common_maps_data_dict['prior_map_vectors'][prior_bold_idx]
-    else:
-        spatial_info['prior_maps'] = None
 
     spatial_info['NPR_maps'] = prior_fit_out['C']
     temporal_info['NPR_time'] = prior_fit_out['W']
@@ -258,10 +248,10 @@ def plot_freqs(ax,timeseries, TR, frame_mask):
     return freqs, psds, y_max
 
 
-def scan_diagnosis(CR_data_dict, maps_data_dict, temporal_info, spatial_info, plot_seed_frequencies={}, brainmap_percent_threshold=10, display_censoring=True):
-    TR = CR_data_dict['CR_data_dict']['TR']
+def scan_diagnosis(CR_data_dict, timeseries, common_anat_ref_file, common_mask_file, temporal_info, spatial_info, plot_seed_frequencies={}, brainmap_percent_threshold=10, display_censoring=True):
+    TR = CR_data_dict['TR']
 
-    total_time_length = len(CR_data_dict['CR_data_dict']['frame_mask'])
+    total_time_length = len(CR_data_dict['frame_mask'])
     n_frames_per_fig = 1000 # max 1000 frames per figure
     num_figs = int(np.ceil(total_time_length/n_frames_per_fig))
     start_time = 0
@@ -271,16 +261,16 @@ def scan_diagnosis(CR_data_dict, maps_data_dict, temporal_info, spatial_info, pl
         start_time+=n_frames_per_fig
 
         [
-            timeseries, frame_mask, motion_params_df,
+            timeseries_subset, frame_mask, motion_params_df,
             FD_trace, DVARS, mse_trace,
             CR_VE_temporal, CR_var_temporal,
             global_signal, WM_trace, CSF_trace, edge_trace,
             DR_bold_time, DR_confound_time, SBC_time, NPR_time,
-            ] = prep_temporal_subset_input(plot_time_subset, CR_data_dict, temporal_info)
+            ] = prep_temporal_subset_input(plot_time_subset, CR_data_dict, timeseries, temporal_info)
 
         time0 = plot_time_subset.start
         fig,axes = temporal_diagnosis_plot(
-            time0, timeseries, frame_mask, TR, motion_params_df,
+            time0, timeseries_subset, frame_mask, TR, motion_params_df,
             FD_trace, DVARS, mse_trace,
             CR_VE_temporal, CR_var_temporal,
             global_signal, WM_trace, CSF_trace, edge_trace,
@@ -289,31 +279,29 @@ def scan_diagnosis(CR_data_dict, maps_data_dict, temporal_info, spatial_info, pl
         temporal_fig_list.append(fig)
         plt.close(fig)
 
-    fig2 = spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_threshold=brainmap_percent_threshold)
+    fig2 = spatial_diagnosis_plot(common_anat_ref_file, common_mask_file, spatial_info, brainmap_percent_threshold=brainmap_percent_threshold)
     plt.close(fig2)
     return temporal_fig_list, fig2
 
 
-def prep_temporal_subset_input(plot_time_subset, CR_data_dict, temporal_info):
-    CR_CR_data_dict = CR_data_dict['CR_data_dict']
-
-    frame_mask = CR_CR_data_dict['frame_mask'][plot_time_subset]
+def prep_temporal_subset_input(plot_time_subset, CR_data_dict, timeseries, temporal_info):
+    frame_mask = CR_data_dict['frame_mask'][plot_time_subset]
     # the motion parameters are the entire original length, so both the time_range from confound_correction and plot_time_subset must be applied
-    time_range = CR_CR_data_dict['time_range']
-    motion_params_df = CR_CR_data_dict['motion_params_df'][time_range.start:time_range.stop][plot_time_subset.start:plot_time_subset.stop]
+    time_range = CR_data_dict['time_range']
+    motion_params_df = CR_data_dict['motion_params_df'][time_range.start:time_range.stop][plot_time_subset.start:plot_time_subset.stop]
 
     # the remaining timeseries were censored with frame_mask, and plot_time_subset is not aligned with the censored time axis
     first = plot_time_subset.start
     last = plot_time_subset.stop # .stop actually returns the max value for range(), which is excluded as an index
     # the idx range must be shifted by the number of censored frames before the first index to match the censored timeseries array
-    frame_mask_full = CR_CR_data_dict['frame_mask']
+    frame_mask_full = CR_data_dict['frame_mask']
     if first>0:
         first -= (frame_mask_full[:first]==False).sum()
     # similarly for the last index
     last -= (frame_mask_full[:last]==False).sum()
     plot_time_subset_censored = range(first,last) # we re-generated a corrected range
 
-    timeseries = CR_data_dict['timeseries'][plot_time_subset_censored]
+    timeseries_subset = timeseries[plot_time_subset_censored]
 
     FD_trace=temporal_info['FD_trace'].to_numpy()[plot_time_subset_censored]
     DVARS=temporal_info['DVARS_pre_correction'][plot_time_subset_censored]
@@ -340,7 +328,7 @@ def prep_temporal_subset_input(plot_time_subset, CR_data_dict, temporal_info):
     WM_trace=temporal_info['WM_trace'][plot_time_subset_censored]
     CSF_trace=temporal_info['CSF_trace'][plot_time_subset_censored]
     return [
-        timeseries, frame_mask, motion_params_df,
+        timeseries_subset, frame_mask, motion_params_df,
         FD_trace, DVARS, mse_trace,
         CR_VE_temporal, CR_var_temporal,
         global_signal, WM_trace, CSF_trace, edge_trace,
@@ -630,12 +618,11 @@ def temporal_diagnosis_plot(
     return fig,axes
 
 
-def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_threshold=10):
-    template_file = maps_data_dict['anat_ref_file']
+def spatial_diagnosis_plot(common_anat_ref_file, common_mask_file, spatial_info, brainmap_percent_threshold=10):
+    template_file = common_anat_ref_file
     dr_maps = spatial_info['DR_bold']
     SBC_maps = spatial_info['seed_map_list']
     NPR_maps = spatial_info['NPR_maps']
-    mask_file = maps_data_dict['mask_file']
 
     # convert to empty list to read len() of 0
     if SBC_maps is None:
@@ -658,7 +645,7 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
             cmap='gray', alpha=1, cbar=False, num_slices=6)
     temporal_std = spatial_info['temporal_std']
     sitk_img = recover_3D(
-        mask_file, temporal_std)
+        common_mask_file, temporal_std)
 
     # select vmax at 95th percentile value
     vector = temporal_std.flatten()
@@ -680,7 +667,7 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
             cmap='gray', alpha=1, cbar=False, num_slices=6)
     predicted_std = spatial_info['predicted_std']
     sitk_img = recover_3D(
-        mask_file, predicted_std)
+        common_mask_file, predicted_std)
 
     # select vmax at 95th percentile value
     vector = predicted_std.flatten()
@@ -700,7 +687,7 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
     plot_3d(axes, scaled, fig2, vmin=0, vmax=1,
             cmap='gray', alpha=1, cbar=False, num_slices=6)
     sitk_img = recover_3D(
-        mask_file, spatial_info['VE_spatial'])
+        common_mask_file, spatial_info['VE_spatial'])
     cbar_list = plot_3d(axes, sitk_img, fig2, vmin=0, vmax=1, cmap='inferno',
             alpha=1, cbar=True, threshold=0.1, num_slices=6)
     for cbar in cbar_list:
@@ -714,7 +701,7 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
     plot_3d(axes, scaled, fig2, vmin=0, vmax=1,
             cmap='gray', alpha=1, cbar=False, num_slices=6)
     sitk_img = recover_3D(
-        mask_file, spatial_info['GS_cov'])
+        common_mask_file, spatial_info['GS_cov'])
     # select vmax at 95th percentile value
     vector = spatial_info['GS_cov'].flatten()
     vector.sort()
@@ -734,9 +721,9 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
         map = dr_maps[i, :]
         threshold = threshold_top_percent(map, top_percent=brainmap_percent_threshold)
         mask=np.abs(map)>=threshold # taking absolute values to include negative weights
-        mask_img = recover_3D(mask_file,mask)        
+        mask_img = recover_3D(common_mask_file,mask)        
         sitk_img = recover_3D(
-            mask_file, map)
+            common_mask_file, map)
         cbar_list = masked_plot(fig2,axes, sitk_img, scaled, mask_img=mask_img, vmax=None)
 
         for cbar in cbar_list:
@@ -752,9 +739,9 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
         map = SBC_maps[i]
         threshold = threshold_top_percent(map, top_percent=brainmap_percent_threshold)
         mask=np.abs(map)>=threshold # taking absolute values to include negative weights
-        mask_img = recover_3D(mask_file,mask)        
+        mask_img = recover_3D(common_mask_file,mask)        
         sitk_img = recover_3D(
-            mask_file, map)
+            common_mask_file, map)
         cbar_list = masked_plot(fig2,axes, sitk_img, scaled, mask_img=mask_img, vmax=None)
 
         for cbar in cbar_list:
@@ -770,9 +757,9 @@ def spatial_diagnosis_plot(maps_data_dict, spatial_info, brainmap_percent_thresh
         map = NPR_maps[i, :]
         threshold = threshold_top_percent(map, top_percent=brainmap_percent_threshold)
         mask=np.abs(map)>=threshold # taking absolute values to include negative weights
-        mask_img = recover_3D(mask_file,mask)        
+        mask_img = recover_3D(common_mask_file,mask)        
         sitk_img = recover_3D(
-            mask_file, map)
+            common_mask_file, map)
         cbar_list = masked_plot(fig2,axes, sitk_img, scaled, mask_img=mask_img, vmax=None)
 
         for cbar in cbar_list:

--- a/rabies/analysis_pkg/diagnosis_pkg/diagnosis_wf.py
+++ b/rabies/analysis_pkg/diagnosis_pkg/diagnosis_wf.py
@@ -7,11 +7,15 @@ from rabies.analysis_pkg.diagnosis_pkg.interfaces import ScanDiagnosis, DatasetD
 from rabies.analysis_pkg.diagnosis_pkg.diagnosis_functions import temporal_external_formating, spatial_external_formating
 
 
-def init_diagnosis_wf(analysis_opts, nativespace_analysis, split_name_list, name="diagnosis_wf"):
+def init_diagnosis_wf(analysis_opts, cr_opts, split_name_list, name="diagnosis_wf"):
 
     workflow = pe.Workflow(name=name)
     inputnode = pe.Node(niu.IdentityInterface(
-        fields=['CR_dict_file', 'common_maps_dict_file', 'sub_maps_dict_file', 'analysis_files_dict', 'native_to_commonspace_transform_list', 'native_to_commonspace_inverse_list']), name='inputnode')
+        fields=['cleaned_bold_file', 'name_source', 'CR_data_dict',
+                'VE_file', 'STD_file', 'CR_STD_file',
+                'sub_mask_file', 'sub_WM_mask_file', 'sub_CSF_mask_file',
+                'common_mask_file', 'common_anat_ref_file',
+                'analysis_files_dict', 'native_to_commonspace_transform_list', 'native_to_commonspace_inverse_list']), name='inputnode')
     outputnode = pe.Node(niu.IdentityInterface(fields=['figure_temporal_diagnosis', 'figure_spatial_diagnosis',
                                                        'dataset_diagnosis_folder', 'temporal_info_csv', 'spatial_VE_nii', 'temporal_std_nii', 'GS_corr_nii', 'GS_cov_nii',
                                                        'CR_prediction_std_nii']), name='outputnode')
@@ -19,11 +23,12 @@ def init_diagnosis_wf(analysis_opts, nativespace_analysis, split_name_list, name
     ScanDiagnosis_node = pe.Node(ScanDiagnosis(prior_bold_idx=analysis_opts.prior_bold_idx,
         prior_confound_idx=analysis_opts.prior_confound_idx,
             plot_seed_frequencies=analysis_opts.plot_seed_frequencies,
-            figure_format=analysis_opts.figure_format, 
-            nativespace_analysis=nativespace_analysis, 
+            figure_format=analysis_opts.figure_format,
+            nativespace_analysis=cr_opts.nativespace_analysis,
             interpolation=analysis_opts.interpolation_sitk,
             brainmap_percent_threshold=analysis_opts.brainmap_percent_threshold,
             rabies_data_type=analysis_opts.data_type,
+            remove_EPI_avg=cr_opts.keep_EPI_average,
             ),
         name='ScanDiagnosis')
 
@@ -35,15 +40,23 @@ def init_diagnosis_wf(analysis_opts, nativespace_analysis, split_name_list, name
 
     spatial_external_formating_node = pe.Node(Function(input_names=['spatial_info'],
                                             output_names=[
-                                                'VE_filename', 'std_filename', 'predicted_std_filename', 
+                                                'VE_filename', 'std_filename', 'predicted_std_filename',
                                                 'GS_corr_filename', 'GS_cov_filename'],
                                         function=spatial_external_formating),
                                 name='spatial_external_formating')
     workflow.connect([
         (inputnode, ScanDiagnosis_node, [
-            ("CR_dict_file", "CR_dict_file"),
-            ("common_maps_dict_file", "common_maps_dict_file"),
-            ("sub_maps_dict_file", "sub_maps_dict_file"),
+            ("cleaned_bold_file", "cleaned_bold_file"),
+            ("name_source", "name_source"),
+            ("CR_data_dict", "CR_data_dict"),
+            ("VE_file", "VE_file"),
+            ("STD_file", "STD_file"),
+            ("CR_STD_file", "CR_STD_file"),
+            ("sub_mask_file", "sub_mask_file"),
+            ("sub_WM_mask_file", "sub_WM_mask_file"),
+            ("sub_CSF_mask_file", "sub_CSF_mask_file"),
+            ("common_mask_file", "common_mask_file"),
+            ("common_anat_ref_file", "common_anat_ref_file"),
             ("analysis_files_dict", "analysis_files_dict"),
             ("native_to_commonspace_transform_list", "native_to_common_transforms"),
             ("native_to_commonspace_inverse_list", "native_to_common_inverses"),
@@ -76,17 +89,11 @@ def init_diagnosis_wf(analysis_opts, nativespace_analysis, split_name_list, name
     if not len(split_name_list)<3:
 
         # this function prepares a dictionary with necessary scan-level inputs for group diagnosis
-        def prep_scan_data(CR_dict_file, maps_dict_file, spatial_info, temporal_info):
-            import pickle
-            with open(CR_dict_file, 'rb') as handle:
-                CR_data_dict = pickle.load(handle)
-            with open(maps_dict_file, 'rb') as handle:
-                maps_data_dict = pickle.load(handle)
-
+        def prep_scan_data(CR_data_dict, common_anat_ref_file, common_mask_file, prior_maps_file, spatial_info, temporal_info):
             scan_data={}
 
             dict_keys = ['temporal_std', 'VE_spatial', 'predicted_std', 'GS_corr', 'GS_cov',
-                            'DR_bold', 'NPR_maps', 'prior_maps', 'seed_map_list']
+                            'DR_bold', 'NPR_maps', 'seed_map_list']
             for key in dict_keys:
                 scan_data[key] = spatial_info[key]
 
@@ -96,22 +103,24 @@ def init_diagnosis_wf(analysis_opts, nativespace_analysis, split_name_list, name
             scan_data['NPR_network_time'] = temporal_info['NPR_time']
             scan_data['SBC_network_time'] = temporal_info['SBC_time']
 
-            scan_data['FD_trace'] = CR_data_dict['CR_data_dict']['FD_trace']
-            scan_data['FD_DVARS_corr'] = CR_data_dict['CR_data_dict']['FD_DVARS_corr']
-            scan_data['tDOF'] = CR_data_dict['CR_data_dict']['tDOF']
-            scan_data['CR_global_std'] = CR_data_dict['CR_data_dict']['CR_global_std']
-            scan_data['VE_total_ratio'] = CR_data_dict['CR_data_dict']['VE_total_ratio']
-            scan_data['voxelwise_mean'] = CR_data_dict['CR_data_dict']['voxelwise_mean']
+            scan_data['FD_trace'] = CR_data_dict['FD_trace']
+            scan_data['FD_DVARS_corr'] = CR_data_dict['FD_DVARS_corr']
+            scan_data['tDOF'] = CR_data_dict['tDOF']
+            scan_data['CR_global_std'] = CR_data_dict['CR_global_std']
+            scan_data['VE_total_ratio'] = CR_data_dict['VE_total_ratio']
+            scan_data['voxelwise_mean'] = CR_data_dict['voxelwise_mean']
 
-            scan_data['name_source'] = CR_data_dict['name_source']
-            scan_data['anat_ref_file'] = maps_data_dict['anat_ref_file']
-            scan_data['mask_file'] = maps_data_dict['mask_file']
+            scan_data['name_source'] = temporal_info['name_source']
+            scan_data['anat_ref_file'] = common_anat_ref_file
+            scan_data['mask_file'] = common_mask_file
+            scan_data['prior_maps_file'] = prior_maps_file
             return scan_data
 
-        prep_scan_data_node = pe.Node(Function(input_names=['CR_dict_file', 'maps_dict_file', 'spatial_info', 'temporal_info'],
+        prep_scan_data_node = pe.Node(Function(input_names=['CR_data_dict', 'common_anat_ref_file', 'common_mask_file', 'prior_maps_file', 'spatial_info', 'temporal_info'],
                                             output_names=['scan_data'],
                                         function=prep_scan_data),
                                 name='prep_scan_data_node')
+        prep_scan_data_node.inputs.prior_maps_file = analysis_opts.prior_maps
 
         # calculate the number of scans combined in diagnosis
         num_scan = len(split_name_list)
@@ -135,11 +144,15 @@ def init_diagnosis_wf(analysis_opts, nativespace_analysis, split_name_list, name
         DatasetDiagnosis_node.inputs.group_avg_prior = analysis_opts.group_avg_prior
         DatasetDiagnosis_node.inputs.brainmap_percent_threshold = analysis_opts.brainmap_percent_threshold
         DatasetDiagnosis_node.inputs.add_smoothing = analysis_opts.qc_smooth_maps
+        DatasetDiagnosis_node.inputs.interpolation = analysis_opts.interpolation_sitk
+        DatasetDiagnosis_node.inputs.rabies_data_type = analysis_opts.data_type
+        DatasetDiagnosis_node.inputs.prior_bold_idx = analysis_opts.prior_bold_idx
 
         workflow.connect([
             (inputnode, prep_scan_data_node, [
-                ("CR_dict_file", "CR_dict_file"),
-                ("common_maps_dict_file", "maps_dict_file"),
+                ("CR_data_dict", "CR_data_dict"),
+                ("common_anat_ref_file", "common_anat_ref_file"),
+                ("common_mask_file", "common_mask_file"),
                 ]),
             (ScanDiagnosis_node, prep_scan_data_node, [
                 ("spatial_info", "spatial_info"),

--- a/rabies/analysis_pkg/diagnosis_pkg/interfaces.py
+++ b/rabies/analysis_pkg/diagnosis_pkg/interfaces.py
@@ -10,9 +10,27 @@ from nipype.interfaces.base import (
 
 
 class ScanDiagnosisInputSpec(BaseInterfaceInputSpec):
-    CR_dict_file = File(exists=True, mandatory=True, desc="Dictionary with prepared input matrices from confound correction.")
-    common_maps_dict_file = File(exists=True, mandatory=True, desc="Brain maps and masks in the commonspace")
-    sub_maps_dict_file = File(exists=True, mandatory=True, desc="Brain maps and masks in the subject' space, either native or common.")
+    cleaned_bold_file = File(exists=True, mandatory=True,
+        desc="Cleaned/confound-corrected 4D EPI timeseries for this scan, in the analysis space (native or commonspace).")
+    name_source = File(exists=True, mandatory=True,
+        desc="The original raw EPI file, used only to name outputs consistently with the rest of RABIES.")
+    CR_data_dict = traits.Dict(
+        desc="Confound correction QC dict for this scan (FD_trace, tDOF, frame_mask, TR, ...); 'voxelwise_mean' is also read from it if remove_EPI_avg is True.")
+    remove_EPI_avg = traits.Bool(False, usedefault=True,
+        desc="Whether the average was kept in the cleaned timeseries and must be removed prior to analysis.")
+    VE_file = File(exists=True, mandatory=True, desc="Variance explained (R^2) map from confound regression.")
+    STD_file = File(exists=True, mandatory=True, desc="Temporal standard deviation map on the cleaned timeseries.")
+    CR_STD_file = File(exists=True, mandatory=True, desc="Temporal standard deviation map on the predicted confound timeseries.")
+
+    # subject-space definition (native or commonspace, wherever confound correction ran)
+    sub_mask_file = File(exists=True, mandatory=True, desc="Brain mask in the subject's analysis space.")
+    sub_WM_mask_file = traits.Either(File(exists=True), None, desc="WM mask in the subject's analysis space.")
+    sub_CSF_mask_file = traits.Either(File(exists=True), None, desc="CSF mask in the subject's analysis space.")
+
+    # commonspace definition (always commonspace, used for display and group comparison)
+    common_mask_file = File(exists=True, mandatory=True, desc="Brain mask in commonspace.")
+    common_anat_ref_file = File(exists=True, mandatory=True, desc="Anatomical template in commonspace.")
+
     analysis_files_dict = traits.Dict(
         desc="A dictionary regrouping relevant output files from analysis.")
     prior_bold_idx = traits.List(
@@ -62,21 +80,32 @@ class ScanDiagnosis(BaseInterface):
     output_spec = ScanDiagnosisOutputSpec
 
     def _run_interface(self, runtime):
-        import pickle
-        with open(self.inputs.CR_dict_file, 'rb') as handle:
-            CR_data_dict = pickle.load(handle)
-        with open(self.inputs.common_maps_dict_file, 'rb') as handle:
-            common_maps_data_dict = pickle.load(handle)
-        with open(self.inputs.sub_maps_dict_file, 'rb') as handle:
-            sub_maps_data_dict = pickle.load(handle)
+        import pathlib
+        from rabies.analysis_pkg.utils import load_resample_analysis_maps
 
         figure_format = self.inputs.figure_format
+        CR_data_dict = self.inputs.CR_data_dict
+        nativespace_analysis = self.inputs.nativespace_analysis
+        filename_split = pathlib.Path(self.inputs.name_source).name.rsplit(".nii")[0]
+
+        # subject-space data (matches wherever confound correction ran): timeseries + WM/CSF/edge indices.
+        # no resampling is needed here -- native_WM_mask/native_brain_mask etc. are already in this space --
+        # so anat_ref_file is passed as sub_mask_file itself, purely as a placeholder.
+        sub_space_maps_loaded = load_resample_analysis_maps(
+            self.inputs.sub_mask_file, self.inputs.sub_mask_file,
+            cleaned_bold_file=self.inputs.cleaned_bold_file, CR_data_dict=CR_data_dict, remove_EPI_avg=self.inputs.remove_EPI_avg,
+            WM_mask_file=self.inputs.sub_WM_mask_file, CSF_mask_file=self.inputs.sub_CSF_mask_file, compute_edge_idx=True,
+            output_prefix=filename_split)
+
+        VE_spatial = sitk.GetArrayFromImage(sitk.ReadImage(self.inputs.VE_file))[sub_space_maps_loaded['volume_indices']]
+        temporal_std = sitk.GetArrayFromImage(sitk.ReadImage(self.inputs.STD_file))[sub_space_maps_loaded['volume_indices']]
+        predicted_std = sitk.GetArrayFromImage(sitk.ReadImage(self.inputs.CR_STD_file))[sub_space_maps_loaded['volume_indices']]
 
         # convert to an integer list
         prior_bold_idx = [int(i) for i in self.inputs.prior_bold_idx]
         prior_confound_idx = [int(i) for i in self.inputs.prior_confound_idx]
 
-        if self.inputs.nativespace_analysis:
+        if nativespace_analysis:
             resampling_specs = {'transforms':self.inputs.native_to_common_transforms,
                                 'inverses':self.inputs.native_to_common_inverses,
                                 'interpolation':self.inputs.interpolation,
@@ -86,17 +115,17 @@ class ScanDiagnosis(BaseInterface):
             resampling_specs = {}
 
         temporal_info, spatial_info = diagnosis_functions.compute_spatiotemporal_features(
-            CR_data_dict, sub_maps_data_dict, common_maps_data_dict, self.inputs.analysis_files_dict, 
-            prior_bold_idx, prior_confound_idx,
-            nativespace_analysis=self.inputs.nativespace_analysis,resampling_specs=resampling_specs)
+            self.inputs.name_source, CR_data_dict, VE_spatial, temporal_std, predicted_std,
+            self.inputs.sub_mask_file, sub_space_maps_loaded, self.inputs.common_mask_file, self.inputs.common_anat_ref_file,
+            self.inputs.analysis_files_dict, prior_bold_idx, prior_confound_idx,
+            nativespace_analysis=nativespace_analysis, resampling_specs=resampling_specs)
 
-        temporal_fig_list, fig2 = diagnosis_functions.scan_diagnosis(CR_data_dict, common_maps_data_dict, temporal_info,
-                                   spatial_info, plot_seed_frequencies=self.inputs.plot_seed_frequencies, 
+        temporal_fig_list, fig2 = diagnosis_functions.scan_diagnosis(CR_data_dict, sub_space_maps_loaded['timeseries'],
+                                   self.inputs.common_anat_ref_file, self.inputs.common_mask_file, temporal_info,
+                                   spatial_info, plot_seed_frequencies=self.inputs.plot_seed_frequencies,
                                    brainmap_percent_threshold=self.inputs.brainmap_percent_threshold)
 
-        import pathlib
-        filename_template = pathlib.Path(CR_data_dict['name_source']).name.rsplit(".nii")[0]
-        figure_path = os.path.abspath(filename_template)
+        figure_path = os.path.abspath(filename_split)
         spatial_fig_file = figure_path+f'_spatial_diagnosis.{figure_format}'
         fig2.savefig(spatial_fig_file, bbox_inches='tight')
 
@@ -147,6 +176,12 @@ class DatasetDiagnosisInputSpec(BaseInterfaceInputSpec):
         desc="Input percentage value for thresholding images.")
     add_smoothing = traits.Bool(
         desc="When to smooth all brain maps prior to QC metric computation with 0.3mm kernel.")
+    interpolation = traits.Int(
+        desc="Provide an SITK interpolator, used to resample prior_maps into commonspace.")
+    rabies_data_type = traits.Int(
+        desc="Integer specifying SimpleITK data type.")
+    prior_bold_idx = traits.List(
+        desc="The index for the ICA components that correspond to bold sources, matching the DR/NPR network ordering.")
 
 
 class DatasetDiagnosisOutputSpec(TraitedSpec):
@@ -169,6 +204,7 @@ class DatasetDiagnosis(BaseInterface):
         import matplotlib.pyplot as plt
         from rabies.utils import flatten_list
         from .dataset_QC import generate_dataset_QC,QC_distributions
+        from ..utils import load_resample_analysis_maps
 
         figure_format = self.inputs.figure_format
 
@@ -196,8 +232,19 @@ class DatasetDiagnosis(BaseInterface):
 
         template_file = merged[0]['anat_ref_file']
         mask_file = merged[0]['mask_file']
-        brain_mask = sitk.GetArrayFromImage(sitk.ReadImage(mask_file))
-        volume_indices = brain_mask.astype(bool)
+        prior_maps_file = merged[0]['prior_maps_file']
+
+        commonspace_maps_loaded = load_resample_analysis_maps(
+            mask_file, template_file,
+            prior_maps=prior_maps_file,
+            interpolation=self.inputs.interpolation, rabies_data_type=self.inputs.rabies_data_type,
+            output_prefix=f'dataset_diagnosis_common')
+        volume_indices = commonspace_maps_loaded['volume_indices']
+        prior_map_vectors = commonspace_maps_loaded['prior_map_vectors']
+        if prior_map_vectors is not None:
+            prior_bold_idx = [int(i) for i in self.inputs.prior_bold_idx]
+            prior_map_vectors = prior_map_vectors[prior_bold_idx]
+
 
         scan_name_list=[]
         mean_maps=[]
@@ -370,7 +417,7 @@ class DatasetDiagnosis(BaseInterface):
                 num_priors = DR_maps_list.shape[1]
                 prior_maps = np.median(DR_maps_list,axis=0)[:,non_zero_voxels]
             else:
-                prior_maps = scan_data['prior_maps'][:,non_zero_voxels]
+                prior_maps = prior_map_vectors[:,non_zero_voxels]
                 num_priors = prior_maps.shape[0]
 
             for i in range(num_priors):
@@ -399,7 +446,7 @@ class DatasetDiagnosis(BaseInterface):
                 num_priors = NPR_maps_list.shape[1]
                 prior_maps = np.median(NPR_maps_list,axis=0)[:,non_zero_voxels]
             else:
-                prior_maps = scan_data['prior_maps'][:,non_zero_voxels]
+                prior_maps = prior_map_vectors[:,non_zero_voxels]
                 num_priors = prior_maps.shape[0]
 
             for i in range(num_priors):

--- a/rabies/analysis_pkg/main_wf.py
+++ b/rabies/analysis_pkg/main_wf.py
@@ -97,8 +97,7 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
 
     # prepare analysis workflow
     analysis_output = os.path.abspath(str(analysis_opts.output_dir))
-    analysis_wf = init_analysis_wf(
-        opts=analysis_opts)
+    analysis_wf = init_analysis_wf(analysis_opts, cr_opts)
 
     '''
     PREPARE DATASINKS
@@ -150,14 +149,16 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
             ("CR_STD_file_path", "CR_STD_file"),
             ("input_bold", "name_source"),
             ]),
-        (load_CR_dict_node, analysis_wf, [
-            ("CR_dict_file", "subject_inputnode.CR_dict_file"),
+        (conf_outputnode, analysis_wf, [
+            ("cleaned_path", "subject_inputnode.cleaned_bold_file"),
+            ("input_bold", "subject_inputnode.name_source"),
+            ("data_dict", "subject_inputnode.CR_data_dict"),
             ]),
         (analysis_wf, main_analysis_datasink, [
             ("outputnode.matrix_data_file", "matrix_data_file"),
             ("outputnode.matrix_fig", "matrix_fig"),
-            ("outputnode.corr_map_file", "seed_correlation_maps"),
-            ("outputnode.seed_timecourse_csv", "seed_timecourse_csv"),
+            ("outputnode.corr_map_file_list", "seed_correlation_maps"),
+            ("outputnode.seed_timecourse_csv_list", "seed_timecourse_csv"),
             ("outputnode.DR_nii_file", "dual_regression_nii"),
             ("outputnode.dual_regression_timecourse_csv", "dual_regression_timecourse_csv"),
             ("outputnode.NPR_prior_timecourse_csv", "NPR_prior_timecourse_csv"),
@@ -214,13 +215,17 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
         # only if inputs are in commonspace then analysis computations are also in commonspace
         if not cr_opts.nativespace_analysis:
             workflow.connect([
-                (load_maps_dict_common_node, analysis_wf, [
-                    ("maps_dict_file", "subject_inputnode.maps_dict_file"),
-                    ]),
                 (load_maps_dict_common_node, load_CR_dict_node, [
                     ("maps_dict_file", "maps_dict_file"),
                     ]),
                 ])
+
+            # the commonspace mask/template are the same for every scan, and no transform
+            # is needed since seeds/prior_maps/atlas are already in commonspace
+            analysis_wf.inputs.subject_inputnode.mask_file = split_dict[split_name]["commonspace_mask"]
+            analysis_wf.inputs.subject_inputnode.anat_ref_file = split_dict[split_name]["commonspace_resampled_template"]
+            analysis_wf.inputs.subject_inputnode.to_analysis_space_transform_list = []
+            analysis_wf.inputs.subject_inputnode.to_analysis_space_inverse_list = []
 
     # if inputs are in native space, then subject specific maps are loaded
     if cr_opts.nativespace_analysis:
@@ -246,13 +251,14 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
                 ("commonspace_to_native_inverse_list", "inverse_list"),
                 ("input_bold", "name_source"),
                 ]),
-            (load_maps_dict_native_node, analysis_wf, [
-                ("maps_dict_file", "subject_inputnode.maps_dict_file"),
-                ]),
             (load_maps_dict_native_node, load_CR_dict_node, [
                 ("maps_dict_file", "maps_dict_file"),
                 ]),
             (conf_outputnode, analysis_wf, [
+                ("native_brain_mask", "subject_inputnode.mask_file"),
+                ("native_bold_ref", "subject_inputnode.anat_ref_file"),
+                ("commonspace_to_native_transform_list", "subject_inputnode.to_analysis_space_transform_list"),
+                ("commonspace_to_native_inverse_list", "subject_inputnode.to_analysis_space_inverse_list"),
                 ("native_to_commonspace_transform_list", "subject_inputnode.native_to_commonspace_transform_list"),
                 ("native_to_commonspace_inverse_list", "subject_inputnode.native_to_commonspace_inverse_list"),
                 ]),
@@ -407,8 +413,8 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
         if len(analysis_opts.seed_list) > 0:
             workflow.connect([
                 (analysis_wf, prep_analysis_files_dict_node, [
-                    ("outputnode.joined_corr_map_file", "seed_map_files"),
-                    ("outputnode.joined_seed_timecourse_csv", "seed_timecourse_csv"),
+                    ("outputnode.corr_map_file_list", "seed_map_files"),
+                    ("outputnode.seed_timecourse_csv_list", "seed_timecourse_csv"),
                     ]),
                 ])
         else:

--- a/rabies/analysis_pkg/main_wf.py
+++ b/rabies/analysis_pkg/main_wf.py
@@ -82,18 +82,6 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
     conf_outputnode.inputs.split_dict = split_dict
     conf_outputnode.inputs.target_list = target_list
 
-    # prepare dictionary for seed files
-    seed_dict = {}
-    for seed_file,seed_name in zip(analysis_opts.seed_list, analysis_opts.seed_name_list):
-        seed_dict[seed_name] = seed_file
-
-    load_CR_dict_node = pe.Node(Function(input_names=['maps_dict_file', 'cleaned_bold_file', 'CR_data_dict', 'VE_file', 'STD_file', 'CR_STD_file', 'name_source', 'remove_intercept'],
-                                           output_names=[
-                                               'CR_dict_file'],
-                                       function=load_CR_input_dict),
-                              name='load_CR_dict_node')
-    # if the average was kept, it needs to be removed before analysis computations
-    load_CR_dict_node.inputs.remove_intercept = cr_opts.keep_EPI_average
 
     # prepare analysis workflow
     analysis_output = os.path.abspath(str(analysis_opts.output_dir))
@@ -141,14 +129,6 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
         (main_split, conf_outputnode, [
             ("split_name", "split_name"),
             ]),
-        (conf_outputnode, load_CR_dict_node, [
-            ("cleaned_path", "cleaned_bold_file"),
-            ("data_dict", "CR_data_dict"),
-            ("VE_file_path", "VE_file"),
-            ("STD_file_path", "STD_file"),
-            ("CR_STD_file_path", "CR_STD_file"),
-            ("input_bold", "name_source"),
-            ]),
         (conf_outputnode, analysis_wf, [
             ("cleaned_path", "subject_inputnode.cleaned_bold_file"),
             ("input_bold", "subject_inputnode.name_source"),
@@ -169,57 +149,22 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
             ]),
         ])
     
-    analysis_wf.inputs.group_inputnode.commonspace_template = split_dict[split_name_list[0]]["commonspace_resampled_template"]
+    split_name = split_name_list[0] # can take the commonspace files from any subject, they are all identical
+    analysis_wf.inputs.group_inputnode.commonspace_template = split_dict[split_name]["commonspace_resampled_template"]
 
     '''
     CONDITIONAL NODES AND CONNECTIONS
     '''
 
+    # prepare dictionary for seed files
+    seed_dict = {seed_name: seed_file for seed_file, seed_name in zip(analysis_opts.seed_list, analysis_opts.seed_name_list)}
+
     # if inputs are in commmonspace, then analysis is computed with commonspace files
     # if --data_diagnosis, then commonspace files are needed for plotting results
     if not cr_opts.nativespace_analysis or analysis_opts.data_diagnosis:
-        load_maps_dict_common_node = pe.Node(Function(input_names=['mask_file', 'WM_mask_file', 'CSF_mask_file', 'atlas_file', 'anat_ref_file',
-                                                            'seed_dict', 'prior_maps', 'transform_list','inverse_list', 'name_source', 'interpolation', 'rabies_data_type'],
-                                            output_names=[
-                                                'maps_dict_file', 'resampled_seed_filelist', 'resampled_atlas_file'],
-                                        function=load_maps_dict),
-                                name='load_maps_dict_common_node')
-        load_maps_dict_common_node.inputs.atlas_file = analysis_opts.ROI_labels_file
-        load_maps_dict_common_node.inputs.seed_dict = seed_dict
-        load_maps_dict_common_node.inputs.prior_maps = analysis_opts.prior_maps
-        load_maps_dict_common_node.inputs.interpolation = analysis_opts.interpolation_sitk
-        load_maps_dict_common_node.inputs.rabies_data_type = analysis_opts.data_type
-
-        split_name = split_name_list[0] # can take the commonspace files from any subject, they are all identical
-        load_maps_dict_common_node.inputs.mask_file = split_dict[split_name]["commonspace_mask"]
-        load_maps_dict_common_node.inputs.WM_mask_file = split_dict[split_name]["commonspace_WM_mask"]
-        load_maps_dict_common_node.inputs.CSF_mask_file = split_dict[split_name]["commonspace_CSF_mask"]
-        load_maps_dict_common_node.inputs.anat_ref_file = split_dict[split_name]["commonspace_resampled_template"]
-        load_maps_dict_common_node.inputs.transform_list = []
-        load_maps_dict_common_node.inputs.inverse_list = []
-        load_maps_dict_common_node.inputs.name_source = 'commonspace.nii'
-
-        if len(analysis_opts.seed_list)>0:
-            workflow.connect([
-                (load_maps_dict_common_node, commonspace_analysis_datasink, [
-                    ("resampled_seed_filelist", "commonspace_resampled_seeds"),
-                    ]),
-                ])
-        if analysis_opts.ROI_labels_file is not None:
-            workflow.connect([
-                (load_maps_dict_common_node, commonspace_analysis_datasink, [
-                    ("resampled_atlas_file", "commonspace_resampled_atlas"),
-                    ]),
-                ])
-
+        
         # only if inputs are in commonspace then analysis computations are also in commonspace
         if not cr_opts.nativespace_analysis:
-            workflow.connect([
-                (load_maps_dict_common_node, load_CR_dict_node, [
-                    ("maps_dict_file", "maps_dict_file"),
-                    ]),
-                ])
-
             # the commonspace mask/template are the same for every scan, and no transform
             # is needed since seeds/prior_maps/atlas are already in commonspace
             analysis_wf.inputs.subject_inputnode.mask_file = split_dict[split_name]["commonspace_mask"]
@@ -227,32 +172,48 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
             analysis_wf.inputs.subject_inputnode.to_analysis_space_transform_list = []
             analysis_wf.inputs.subject_inputnode.to_analysis_space_inverse_list = []
 
+
+        to_analysis_space_common_node = pe.Node(Function(input_names=['atlas_file', 'anat_ref_file', 'seed_dict', 'transform_list', 'inverse_list'],
+                                            output_names=[
+                                                'resampled_seed_filelist', 'resampled_atlas_file'],
+                                        function=to_analysis_space),
+                                name='to_analysis_space_common_node')
+
+        
+        to_analysis_space_common_node.inputs.atlas_file = analysis_opts.ROI_labels_file
+        to_analysis_space_common_node.inputs.seed_dict = seed_dict
+        to_analysis_space_common_node.inputs.anat_ref_file = split_dict[split_name]["commonspace_resampled_template"]
+        to_analysis_space_common_node.inputs.transform_list = []
+        to_analysis_space_common_node.inputs.inverse_list = []
+
+        if len(analysis_opts.seed_list)>0:
+            workflow.connect([
+                (to_analysis_space_common_node, commonspace_analysis_datasink, [
+                    ("resampled_seed_filelist", "commonspace_resampled_seeds"),
+                    ]),
+                ])
+        if analysis_opts.ROI_labels_file is not None:
+            workflow.connect([
+                (to_analysis_space_common_node, commonspace_analysis_datasink, [
+                    ("resampled_atlas_file", "commonspace_resampled_atlas"),
+                    ]),
+                ])
+
     # if inputs are in native space, then subject specific maps are loaded
     if cr_opts.nativespace_analysis:
-        load_maps_dict_native_node = pe.Node(Function(input_names=['mask_file', 'WM_mask_file', 'CSF_mask_file', 'atlas_file', 'anat_ref_file', 
-                                                            'seed_dict', 'prior_maps', 'transform_list','inverse_list', 'name_source', 'interpolation', 'rabies_data_type'],
+        to_analysis_space_native_node = pe.Node(Function(input_names=['atlas_file', 'anat_ref_file', 'seed_dict', 'transform_list', 'inverse_list'],
                                             output_names=[
-                                                'maps_dict_file', 'resampled_seed_filelist', 'resampled_atlas_file'],
-                                        function=load_maps_dict),
-                                name='load_maps_dict_native_node')
-        load_maps_dict_native_node.inputs.atlas_file = analysis_opts.ROI_labels_file
-        load_maps_dict_native_node.inputs.seed_dict = seed_dict
-        load_maps_dict_native_node.inputs.prior_maps = analysis_opts.prior_maps
-        load_maps_dict_native_node.inputs.interpolation = analysis_opts.interpolation_sitk
-        load_maps_dict_native_node.inputs.rabies_data_type = analysis_opts.data_type
+                                                'resampled_seed_filelist', 'resampled_atlas_file'],
+                                        function=to_analysis_space),
+                                name='to_analysis_space_native_node')
+        to_analysis_space_native_node.inputs.atlas_file = analysis_opts.ROI_labels_file
+        to_analysis_space_native_node.inputs.seed_dict = seed_dict
 
         workflow.connect([
-            (conf_outputnode, load_maps_dict_native_node, [
-                ("native_brain_mask", "mask_file"),
-                ("native_WM_mask", "WM_mask_file"),
-                ("native_CSF_mask", "CSF_mask_file"),
+            (conf_outputnode, to_analysis_space_native_node, [
                 ("native_bold_ref", "anat_ref_file"),
                 ("commonspace_to_native_transform_list", "transform_list"),
                 ("commonspace_to_native_inverse_list", "inverse_list"),
-                ("input_bold", "name_source"),
-                ]),
-            (load_maps_dict_native_node, load_CR_dict_node, [
-                ("maps_dict_file", "maps_dict_file"),
                 ]),
             (conf_outputnode, analysis_wf, [
                 ("native_brain_mask", "subject_inputnode.mask_file"),
@@ -265,13 +226,13 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
             ])
         if len(analysis_opts.seed_list)>0:
             workflow.connect([
-                (load_maps_dict_native_node, nativespace_analysis_datasink, [
+                (to_analysis_space_native_node, nativespace_analysis_datasink, [
                     ("resampled_seed_filelist", "nativespace_resampled_seeds"),
                     ]),
                 ])
         if analysis_opts.ROI_labels_file is not None:
             workflow.connect([
-                (load_maps_dict_native_node, nativespace_analysis_datasink, [
+                (to_analysis_space_native_node, nativespace_analysis_datasink, [
                     ("resampled_atlas_file", "nativespace_resampled_atlas"),
                     ]),
                 ])
@@ -332,14 +293,16 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
                                         function=prep_analysis_files_dict),
                                 name='analysis_prep_analysis_files_dict')
 
-        diagnosis_wf = init_diagnosis_wf(analysis_opts, cr_opts.nativespace_analysis, split_name_list, name="diagnosis_wf")
+        diagnosis_wf = init_diagnosis_wf(analysis_opts, cr_opts, split_name_list, name="diagnosis_wf")
 
         workflow.connect([
-            (load_CR_dict_node, diagnosis_wf, [
-                ("CR_dict_file", "inputnode.CR_dict_file"),
-                ]),
-            (load_maps_dict_common_node, diagnosis_wf, [
-                ("maps_dict_file", "inputnode.common_maps_dict_file"),
+            (conf_outputnode, diagnosis_wf, [
+                ("cleaned_path", "inputnode.cleaned_bold_file"),
+                ("input_bold", "inputnode.name_source"),
+                ("data_dict", "inputnode.CR_data_dict"),
+                ("VE_file_path", "inputnode.VE_file"),
+                ("STD_file_path", "inputnode.STD_file"),
+                ("CR_STD_file_path", "inputnode.CR_STD_file"),
                 ]),
             (prep_analysis_files_dict_node, diagnosis_wf, [
                 ("analysis_files_dict", "inputnode.analysis_files_dict"),
@@ -355,22 +318,25 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
                 ("outputnode.GS_cov_nii", "GS_cov_nii"),
                 ]),
             ])
+
+        # the commonspace mask/template are the same for every scan, regardless of native/commonspace analysis
+        diagnosis_wf.inputs.inputnode.common_mask_file = split_dict[split_name]["commonspace_mask"]
+        diagnosis_wf.inputs.inputnode.common_anat_ref_file = split_dict[split_name]["commonspace_resampled_template"]
+
         if cr_opts.nativespace_analysis:
             workflow.connect([
-                (load_maps_dict_native_node, diagnosis_wf, [
-                    ("maps_dict_file", "inputnode.sub_maps_dict_file"),
-                    ]),
                 (conf_outputnode, diagnosis_wf, [
+                    ("native_brain_mask", "inputnode.sub_mask_file"),
+                    ("native_WM_mask", "inputnode.sub_WM_mask_file"),
+                    ("native_CSF_mask", "inputnode.sub_CSF_mask_file"),
                     ("native_to_commonspace_transform_list", "inputnode.native_to_commonspace_transform_list"),
                     ("native_to_commonspace_inverse_list", "inputnode.native_to_commonspace_inverse_list"),
                     ]),
                 ])
         else:
-            workflow.connect([
-                (load_maps_dict_common_node, diagnosis_wf, [
-                    ("maps_dict_file", "inputnode.sub_maps_dict_file"),
-                    ]),
-                ])
+            diagnosis_wf.inputs.inputnode.sub_mask_file = split_dict[split_name]["commonspace_mask"]
+            diagnosis_wf.inputs.inputnode.sub_WM_mask_file = split_dict[split_name]["commonspace_WM_mask"]
+            diagnosis_wf.inputs.inputnode.sub_CSF_mask_file = split_dict[split_name]["commonspace_CSF_mask"]
 
         if analysis_opts.DR_ICA:
             workflow.connect([
@@ -413,10 +379,22 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
         if len(analysis_opts.seed_list) > 0:
             workflow.connect([
                 (analysis_wf, prep_analysis_files_dict_node, [
-                    ("outputnode.corr_map_file_list", "seed_map_files"),
                     ("outputnode.seed_timecourse_csv_list", "seed_timecourse_csv"),
                     ]),
                 ])
+            # spatial maps for diagnosis are always displayed in commonspace
+            if cr_opts.nativespace_analysis:
+                workflow.connect([
+                    (analysis_wf, prep_analysis_files_dict_node, [
+                        ("outputnode.corr_map_file_resampled", "seed_map_files"),
+                        ]),
+                    ])
+            else:
+                workflow.connect([
+                    (analysis_wf, prep_analysis_files_dict_node, [
+                        ("outputnode.corr_map_file_list", "seed_map_files"),
+                        ]),
+                    ])
         else:
             prep_analysis_files_dict_node.inputs.seed_map_files = []
             prep_analysis_files_dict_node.inputs.seed_timecourse_csv = None
@@ -424,44 +402,13 @@ def init_main_analysis_wf(cr_opts, analysis_opts):
     return workflow
 
 
-# this function handles masks/maps that can be either common across subjects in commonspace, or resampled into individual spaces for nativespace analyses
-# in the case of commonspace, this node only runs once, hence saving computations
-# anat_ref_file is an anatomical 3D image that defines the resampling space inputted to antsApplyTransform
-def load_maps_dict(mask_file, WM_mask_file, CSF_mask_file, atlas_file, anat_ref_file,
-                   seed_dict, prior_maps, transform_list, inverse_list, name_source, interpolation, rabies_data_type):
-    import pickle
-    import numpy as np
+def to_analysis_space(atlas_file, anat_ref_file,
+                   seed_dict, transform_list, inverse_list):
     import SimpleITK as sitk
     import os
-    import pathlib  # Better path manipulation
-    from rabies.utils import resample_volumes, antsApplyTransforms
-    from rabies.analysis_pkg.utils import compute_edge_mask
-    mask_img = sitk.ReadImage(mask_file)
-    mask_array = sitk.GetArrayFromImage(mask_img)
-    volume_indices = mask_array.astype(bool)
+    from rabies.utils import antsApplyTransforms
     
-    if WM_mask_file is None:
-        WM_idx = None
-    else:
-        WM_idx = sitk.GetArrayFromImage(
-            sitk.ReadImage(WM_mask_file))[volume_indices].astype(bool)
-    if CSF_mask_file is None:
-        CSF_idx = None
-    else:
-        CSF_idx = sitk.GetArrayFromImage(
-            sitk.ReadImage(CSF_mask_file))[volume_indices].astype(bool)
-
-    edge_idx = compute_edge_mask(mask_array, num_edge_voxels=1)[volume_indices]
-
-    prior_map_vectors = None
-    if prior_maps is not None:
-        resampled_4D_img = resample_volumes(in_img=prior_maps, in_ref=anat_ref_file, transforms_3d_files=transform_list, inverses_3d=inverse_list, 
-                                            motcorr_params_file=None, interpolation=interpolation, rabies_data_type=rabies_data_type, clip_negative=False)
-        resampled_maps = sitk.GetArrayFromImage(resampled_4D_img)
-        prior_map_vectors = resampled_maps[:,volume_indices] # we return the 2D format of map number by voxels
-
     # resample each seed into the right space and then load the seed as an array
-    seed_arr_dict = {}
     seed_name_list = list(seed_dict.keys())
     resampled_seed_filelist = []
     for seed_name in seed_name_list:
@@ -469,77 +416,19 @@ def load_maps_dict(mask_file, WM_mask_file, CSF_mask_file, atlas_file, anat_ref_
         resampled_seed_file = os.path.abspath(f'{seed_name}_resampled.nii.gz')
         antsApplyTransforms(transforms = transform_list, inverses = inverse_list, 
                         input_image = seed_file, ref_image = anat_ref_file, output_filename = resampled_seed_file, interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
-        seed_arr_dict[seed_name] = sitk.GetArrayFromImage(sitk.ReadImage(resampled_seed_file))[volume_indices]
         resampled_seed_filelist.append(resampled_seed_file)
 
     if len(resampled_seed_filelist)==0:
         resampled_seed_filelist = None
 
     if atlas_file is None:
-        atlas_idx = None
-        roi_list = None
         resampled_atlas_file = None
     else:
         resampled_atlas_file = os.path.abspath(f'parcellation_resampled.nii.gz')
         antsApplyTransforms(transforms = transform_list, inverses = inverse_list, 
                         input_image = atlas_file, ref_image = anat_ref_file, output_filename = resampled_atlas_file, interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
-        atlas_idx = sitk.GetArrayFromImage(sitk.ReadImage(resampled_atlas_file))[volume_indices]
 
-        # prepare the list ROI numbers from the atlas for FC matrices
-        # get the complete set of original ROI integers 
-        atlas_data = sitk.GetArrayFromImage(sitk.ReadImage(str(atlas_file))).astype(int)
-        roi_list = []
-        for i in range(1, atlas_data.max()+1):
-            if np.max(i == atlas_data):  # include integers that do have labelled voxels
-                roi_list.append(i)
-
-    maps_dict = {'mask_file':mask_file, 'volume_indices':volume_indices, 'WM_idx':WM_idx, 'CSF_idx':CSF_idx,
-                 'atlas_idx':atlas_idx, 'edge_idx':edge_idx, 'anat_ref_file':anat_ref_file,
-                 'seed_arr_dict':seed_arr_dict, 'prior_map_vectors':prior_map_vectors, 'roi_list':roi_list}
-    
-    filename_split = pathlib.Path(name_source).name.rsplit(".nii")
-    maps_dict_file = os.path.abspath(f'{filename_split[0]}_maps_dict.pkl')
-    with open(maps_dict_file, 'wb') as handle:
-        pickle.dump(maps_dict, handle, protocol=pickle.HIGHEST_PROTOCOL)
-
-    return maps_dict_file, resampled_seed_filelist, resampled_atlas_file
-
-
-# this function loads subject-specific data from confound correction
-def load_CR_input_dict(maps_dict_file, cleaned_bold_file, CR_data_dict, VE_file, STD_file, CR_STD_file, name_source, remove_intercept=False):
-    import pickle
-    import pathlib
-    import os
-    import numpy as np
-    import SimpleITK as sitk
-
-    with open(maps_dict_file, 'rb') as handle:
-        maps_dict = pickle.load(handle)
-
-    volume_indices = maps_dict['volume_indices']
-    timeseries = sitk.GetArrayFromImage(sitk.ReadImage(cleaned_bold_file))[:,volume_indices] # read directly as a 2D array
-
-    if remove_intercept:
-        # remove the intercept that was added since analysis computations expect mean-centered data
-        timeseries -= CR_data_dict['voxelwise_mean']
-
-    VE_spatial = sitk.GetArrayFromImage(
-        sitk.ReadImage(VE_file))[volume_indices]
-    temporal_std = sitk.GetArrayFromImage(
-        sitk.ReadImage(STD_file))[volume_indices]
-    predicted_std = sitk.GetArrayFromImage(
-        sitk.ReadImage(CR_STD_file))[volume_indices]
-
-    sub_dict = {'bold_file':cleaned_bold_file, 'name_source':name_source, 'CR_data_dict':CR_data_dict, 
-            'timeseries':timeseries, 'VE_spatial':VE_spatial, 'temporal_std':temporal_std,
-            'predicted_std':predicted_std}
-    
-    filename_split = pathlib.Path(name_source).name.rsplit(".nii")
-    CR_dict_file = os.path.abspath(f'{filename_split[0]}_data_dict.pkl')
-    with open(CR_dict_file, 'wb') as handle:
-        pickle.dump(sub_dict, handle, protocol=pickle.HIGHEST_PROTOCOL)
-
-    return CR_dict_file
+    return resampled_seed_filelist, resampled_atlas_file
 
 
 def read_confound_workflow(conf_output, cr_opts):

--- a/rabies/analysis_pkg/utils.py
+++ b/rabies/analysis_pkg/utils.py
@@ -18,3 +18,91 @@ def compute_edge_mask(mask_array, num_edge_voxels=1):
         num_voxel += 1
 
     return edge_mask
+
+
+def load_resample_analysis_maps(mask_file, anat_ref_file,
+        transform_list=[], inverse_list=[], seed_dict={}, prior_maps=None, atlas_file=None,
+        cleaned_bold_file=None, CR_data_dict=None, remove_EPI_avg=False,
+        WM_mask_file=None, CSF_mask_file=None, compute_edge_idx=False,
+        interpolation=None, rabies_data_type=None, output_prefix=''):
+    '''
+    Loads, exactly once, every NIfTI input a scan's FC analyses and/or diagnosis may need,
+    as vectorized arrays masked to the brain mask. seed_dict/prior_maps/atlas_file are
+    resampled onto the analysis space (defined by mask_file/anat_ref_file) if transform_list
+    is non-empty; each is skipped (left None/empty) if not provided, so the same function
+    serves callers that only need a subset -- e.g. FC_analysis never passes WM_mask_file/
+    CSF_mask_file/compute_edge_idx, which are diagnosis-only.
+
+    Returns a dict with keys: volume_indices, timeseries, seed_arr_dict, prior_map_vectors,
+    atlas_idx, roi_list, WM_idx, CSF_idx, edge_idx.
+    '''
+    import os
+    import numpy as np
+    import SimpleITK as sitk
+    from rabies.utils import resample_volumes, antsApplyTransforms
+
+    if interpolation is None:
+        interpolation = sitk.sitkLinear
+    if rabies_data_type is None:
+        rabies_data_type = sitk.sitkFloat32
+
+    mask_array = sitk.GetArrayFromImage(sitk.ReadImage(mask_file))
+    volume_indices = mask_array.astype(bool)
+
+    timeseries = None
+    if cleaned_bold_file is not None:
+        timeseries = sitk.GetArrayFromImage(sitk.ReadImage(cleaned_bold_file))[:, volume_indices]
+        if remove_EPI_avg:
+            timeseries = timeseries - CR_data_dict['voxelwise_mean']
+
+    seed_arr_dict = {}
+    for seed_name, seed_file in seed_dict.items():
+        resampled_seed_file = os.path.abspath(f'{output_prefix}_{seed_name}_resampled.nii.gz')
+        antsApplyTransforms(transforms=transform_list, inverses=inverse_list,
+            input_image=seed_file, ref_image=anat_ref_file, output_filename=resampled_seed_file,
+            interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
+        seed_arr_dict[seed_name] = sitk.GetArrayFromImage(sitk.ReadImage(resampled_seed_file))[volume_indices]
+
+    prior_map_vectors = None
+    if prior_maps is not None:
+        resampled_4D_img = resample_volumes(in_img=prior_maps, in_ref=anat_ref_file,
+            transforms_3d_files=transform_list, inverses_3d=inverse_list, motcorr_params_file=None,
+            interpolation=interpolation, rabies_data_type=rabies_data_type, clip_negative=False)
+        prior_map_vectors = sitk.GetArrayFromImage(resampled_4D_img)[:, volume_indices]
+
+    atlas_idx = None
+    roi_list = None
+    if atlas_file is not None:
+        resampled_atlas_file = os.path.abspath(f'{output_prefix}_atlas_resampled.nii.gz')
+        antsApplyTransforms(transforms=transform_list, inverses=inverse_list,
+            input_image=atlas_file, ref_image=anat_ref_file, output_filename=resampled_atlas_file,
+            interpolation='GenericLabel', rabies_data_type=sitk.sitkInt16, clip_negative=False)
+        atlas_idx = sitk.GetArrayFromImage(sitk.ReadImage(resampled_atlas_file))[volume_indices]
+
+        # original (unresampled) atlas defines which ROI integers are present
+        atlas_data = sitk.GetArrayFromImage(sitk.ReadImage(str(atlas_file))).astype(int)
+        roi_list = [i for i in range(1, atlas_data.max() + 1) if np.max(i == atlas_data)]
+
+    WM_idx = None
+    if WM_mask_file is not None:
+        WM_idx = sitk.GetArrayFromImage(sitk.ReadImage(WM_mask_file))[volume_indices].astype(bool)
+
+    CSF_idx = None
+    if CSF_mask_file is not None:
+        CSF_idx = sitk.GetArrayFromImage(sitk.ReadImage(CSF_mask_file))[volume_indices].astype(bool)
+
+    edge_idx = None
+    if compute_edge_idx:
+        edge_idx = compute_edge_mask(mask_array, num_edge_voxels=1)[volume_indices]
+
+    return {
+        'volume_indices': volume_indices,
+        'timeseries': timeseries,
+        'seed_arr_dict': seed_arr_dict,
+        'prior_map_vectors': prior_map_vectors,
+        'atlas_idx': atlas_idx,
+        'roi_list': roi_list,
+        'WM_idx': WM_idx,
+        'CSF_idx': CSF_idx,
+        'edge_idx': edge_idx,
+    }

--- a/rabies/analysis_pkg/utils.py
+++ b/rabies/analysis_pkg/utils.py
@@ -53,7 +53,7 @@ def load_resample_analysis_maps(mask_file, anat_ref_file,
     if cleaned_bold_file is not None:
         timeseries = sitk.GetArrayFromImage(sitk.ReadImage(cleaned_bold_file))[:, volume_indices]
         if remove_EPI_avg:
-            timeseries = timeseries - CR_data_dict['voxelwise_mean']
+            timeseries -= CR_data_dict['voxelwise_mean']
 
     seed_arr_dict = {}
     for seed_name, seed_file in seed_dict.items():


### PR DESCRIPTION
Major rework of the analysis package to get rid of load_CR_input_dict load_maps_dict functions, which would save intermediate .pkl files taking unecessary storage (the timeseries were copied into load_CR_input_dict).
Now the main analysis is handled by a core FCAnalysis interface that computes all operation per scan at once when loading the data.
This required major rewiring of the nipype workflows, and changing several intermediate functions.

The saving on storage space is substantial - the bulk of storage at analysis stage is gone. There is also a meaningful speed gain.

All changes were reviewed by me + Claude AI to confirm that no final output change, only internal processes did.